### PR TITLE
toggle phases after restart (alternative of `Solver::rebuildOrderHeap`)

### DIFF
--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -779,8 +779,8 @@ solve s@Solver{..} assumps = do
         set' rootLevel =<< decisionLevel s
         -- SOLVE:
         nc <- fromIntegral <$> nClauses s
-        let useLuby = True
-            restart_inc = 2 :: Double
+        let useLuby = False -- True
+            restart_inc = 1.75 :: Double
             restart_first = 100 :: Double
             while' :: Double -> Double -> IO Bool
             while' nOfConflicts nOfLearnts = do

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -718,6 +718,16 @@ search s@Solver{..} nOfConflicts nOfLearnts = do
                    -- Reached bound on number of conflicts
                    (s `cancelUntil`) =<< get' rootLevel -- force a restart
                    claRescaleActivityAfterRestart s
+                   let toggle :: Int -> Int
+                       toggle x
+                         | x == lFalse = lTrue
+                         | x == lTrue = lFalse
+                         | otherwise = x
+                       nv = nVars
+                       loop :: Int -> IO ()
+                       loop ((<= nv) -> False) = return ()
+                       loop i = modifyNth phases toggle i >> loop (i + 1)
+                   loop 1
                    incrementStat s NumOfRestart 1
                    return lBottom
              _ -> do

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -779,8 +779,8 @@ solve s@Solver{..} assumps = do
         set' rootLevel =<< decisionLevel s
         -- SOLVE:
         nc <- fromIntegral <$> nClauses s
-        let useLuby = False -- True
-            restart_inc = 1.75 :: Double
+        let useLuby = True
+            restart_inc = 2 :: Double
             restart_first = 100 :: Double
             while' :: Double -> Double -> IO Bool
             while' nOfConflicts nOfLearnts = do


### PR DESCRIPTION
# baseline

```
# 2017-08-31T16:03 /home/narazaki/.local/bin/mios-1.4.1 ; mios 1.4.1
"mios-1.4.1", 1, 200,    12.66
"mios-1.4.1", 2, 225,    42.70
"mios-1.4.1", 3, 250,    87.40
"mios-1.4.1", 4, "een",  5.13
"mios-1.4.1", 5, "bmc",  2.90
"mios-1.4.1", 6, "38b",  18.40
```
