### PR TITLE
Update learnt DB's size as same as MiniSat 2.2 does

### DIFF
--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -43,7 +43,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.4.1 #39Luby #36LBD #40noPhaseRestart #42SLA-ordering"
+versionId = "mios-1.4.1 #36 #39 #40 #43 #42SLA-ordering"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -747,7 +747,7 @@ search s@Solver{..} nOfConflicts = do
                   when (cnt == 0) $ do
                     t' <- (1.5 *) <$> get' learntSAdj
                     set' learntSAdj t'
-                    set' learntSCnt t'
+                    set' learntSCnt $ floor t'
                     modify' maxLearnts (* 1.1)
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -708,9 +708,10 @@ simplifyDB s@Solver{..} = do
 --   all variables are decision variables, that means that the clause set is satisfiable. 'l_False'
 --   if the clause set is unsatisfiable. 'l_Undef' if the bound on number of conflicts is reached.
 {-# INLINABLE search #-}
-search :: Solver -> Int -> Int -> IO Int
-search s@Solver{..} nOfConflicts nOfLearnts = do
+search :: Solver -> Int -> IO Int
+search s@Solver{..} nOfConflicts = do
   -- clear model
+  nOfLearnts <- floor <$> get' maxLearnts
   let
     loop :: Int -> IO Int
     loop conflictC = do
@@ -740,13 +741,23 @@ search s@Solver{..} nOfConflicts nOfLearnts = do
                     setNth level v 0
                   varDecayActivity s
                   claDecayActivity s
+                  -- learnt DB Size Adjustment
+                  modify' learntSCnt (subtract 1)
+                  cnt <- get' learntSCnt
+                  when (cnt == 0) $ do
+                    t' <- (1.5 *) <$> get' learntSAdj
+                    set' learntSAdj t'
+                    set' learntSCnt t'
+                    modify' maxLearnts (* 1.1)
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:
             when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
             k1 <- get' learnts
             k2 <- nAssigns s
-            when (k1 - k2 >= nOfLearnts) $ reduceDB s -- Reduce the set of learnt clauses
+            when (k1 - k2 >= nOfLearnts) $ do   -- This is a cheap check.
+              thr <- floor <$> get' maxLearnts  -- maxLearnts is larger than nOfLearnts always.
+              when (thr < k1 - k2) $ reduceDB s -- Reduce the set of learnt clauses.
             case () of
              _ | k2 == nVars -> do
                    -- Model found:
@@ -817,29 +828,26 @@ solve s@Solver{..} assumps = do
     then return False
     else do set' rootLevel =<< decisionLevel s
             -- SOLVE:
-            nc <- fromIntegral <$> nClauses s
             let useLuby = True
                 nv = fromIntegral nVars :: Double
-                reductionBase = min (nc / 3.0) 5000
-                reductionStep = min nv 1000
                 restartBase = nv
                 restartScale = 4.0 :: Double
                 -- restart based on Luby series
-                while :: Int -> Double -> IO Bool
-                while nRestart nOfLearnts = do
+                while :: Int -> IO Bool
+                while nRestart = do
                   let restartIndex = luby restartScale nRestart
-                  status <- search s (floor (restartBase * restartIndex)) (floor nOfLearnts)
+                  status <- search s (floor (restartBase * restartIndex))
                   if status == lBottom
-                    then while (nRestart + 1) (reductionStep + nOfLearnts)
+                    then while (nRestart + 1)
                     else cancelUntil s 0 >> return (status == lTrue)
-                -- restart based on  geometric series
-                while' :: Double -> Double -> IO Bool
-                while' nOfConflicts nOfLearnts = do
-                  status <- search s (floor nOfConflicts) (floor nOfLearnts)
+                -- restart based on a geometric series
+                while' :: Double -> IO Bool
+                while' nOfConflicts = do
+                  status <- search s (floor nOfConflicts)
                   if status == lBottom
-                    then while' (restartScale * nOfConflicts) (reductionStep + nOfLearnts)
+                    then while' (restartScale * nOfConflicts)
                     else cancelUntil s 0 >> return (status == lTrue)
-            if useLuby then while 0 reductionBase else while' 100 reductionBase
+            if useLuby then while 0 else while' 100
 
 -- | Though 'enqueue' is defined in 'Solver', most functions in M114 use @unsafeEnqueue@.
 {-# INLINABLE unsafeEnqueue #-}

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -81,6 +81,10 @@ data Solver = Solver
 -}
               , varInc     :: !Double'           -- ^ Variable activity increment amount to bump with.
               , rootLevel  :: !Int'              -- ^ Separates incremental and search assumptions.
+{-            Learnt DB Size Adjustment -}
+              , learntSAdj :: Double'            -- ^ used in 'SAT.Mios.Main.search'
+              , learntSCnt :: Double'            -- ^ used in 'SAT.Mios.Main.search'
+              , maxLearnts :: Double'            -- ^ used in 'SAT.Mios.Main.search'
 {-            Working Memory -}
               , ok         :: !Bool'             -- ^ /return value/ holder
               , an'seen    :: !(Vec Int)         -- ^ used in 'SAT.Mios.Main.analyze'
@@ -124,6 +128,10 @@ newSolver conf (CNFDescription nv nc _) = do
 --  <*> new' (variableDecayRate conf)      -- varDecay
     <*> new' 1.0                           -- varInc
     <*> new' 0                             -- rootLevel
+    -- Learnt DB Size Adjustment
+    <*> new' 100                           -- learntSAdj
+    <*> new' 100                           -- learntSCnt
+    <*> new' (fromIntegral nc / 3)         -- maxLearnts
     -- Working Memory
     <*> new' True                          -- ok
     <*> newVec nv 0                        -- an'seen

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -83,7 +83,7 @@ data Solver = Solver
               , rootLevel  :: !Int'              -- ^ Separates incremental and search assumptions.
 {-            Learnt DB Size Adjustment -}
               , learntSAdj :: Double'            -- ^ used in 'SAT.Mios.Main.search'
-              , learntSCnt :: Double'            -- ^ used in 'SAT.Mios.Main.search'
+              , learntSCnt :: Int'               -- ^ used in 'SAT.Mios.Main.search'
               , maxLearnts :: Double'            -- ^ used in 'SAT.Mios.Main.search'
 {-            Working Memory -}
               , ok         :: !Bool'             -- ^ /return value/ holder


### PR DESCRIPTION
### description

The size of learnt clause DB increases in [`search`](https://github.com/shnarazk/minisat/blob/c145428c7c3b8913fa51d2aaec2e838a99049657/core/Solver.cc#L646), controlled by the following parameters:

- The learnt DB expansion period scaling factor `learntsize_adjust_inc` is [1.5](https://github.com/shnarazk/minisat/blob/c145428c7c3b8913fa51d2aaec2e838a99049657/core/Solver.cc#L76).
- The DB scaling factor `learntsize_int` is [1.1](https://github.com/shnarazk/minisat/blob/c145428c7c3b8913fa51d2aaec2e838a99049657/core/Solver.cc#L71).

Mios has only one parameter so far.

### baseline
373fe97

```
# p='', t=1260 on xingu @ 2017-09-11T20:08:54+09:00
"mios-sla", 5, 200,      12.73
"mios-sla", 6, 225,      33.61
"mios-sla", 7, 250,      145.78
"mios-sla", 8, "een",    5.04
"mios-sla", 9, "bmc",    3.24
"mios-sla", 10, "38b",   4.30
```