### PR TITLE
Optimization on SLA-ordering

### DIFF
--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -48,7 +48,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.4.1 #36 #39 #40 #43 #44 #42SLA-ordering"
+versionId = "mios-1.4.1 #36 #39 #40 #43 #44 #42SLA-ordering #45"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios/Clause.hs
+++ b/src/SAT/Mios/Clause.hs
@@ -32,8 +32,7 @@ import SAT.Mios.Types
 -- This matches both of @Clause@ and @GClause@ in MiniSat.
 data Clause = Clause
               {
-                learnt     :: !Bool     -- ^ whether this is a learnt clause
-              , rank       :: !Int'     -- ^ goodness like LBD; computed in 'Ranking'
+                rank       :: !Int'     -- ^ goodness like LBD; computed in 'Ranking'
               , activity   :: !Double'  -- ^ activity of this clause
 --              , protected  :: !Bool'    -- ^ protected from reduce
               , lits       :: !Stack    -- ^ which this clause consists of
@@ -112,7 +111,7 @@ newClauseFromStack l vec = do
     loop ((<= n) -> False) = return ()
     loop i = (setNth v i =<< getNth vec i) >> loop (i + 1)
   loop 0
-  Clause l <$> new' 0 <*> new' 0.0 {- <*> new' False -} <*> return v
+  Clause <$> new' (if l then 1 else 0) <*> new' 0.0 {- <*> new' False -} <*> return v
 
 -------------------------------------------------------------------------------- Clause Vector
 

--- a/src/SAT/Mios/ClausePool.hs
+++ b/src/SAT/Mios/ClausePool.hs
@@ -57,13 +57,15 @@ makeClauseFromStack pool v = do
                 loop i = (setNth lstack i =<< getNth v i) >> loop (i + 1)
             loop 0
             -- the caller (newLearntClause) should set these slots
+            -- * rank
+            -- * protected
             set' (activity c) 0.0
-            -- set' (protected c) False
             return c
 
 -- | Note: only not-too-large and learnt clauses are recycled.
 {-# INLINE putBackToPool #-}
 putBackToPool :: ClausePool -> Clause -> IO ()
-putBackToPool pool c =
-  when (learnt c) $ do let n = realLengthOfStack (lits c) - 3
-                       when (n <= storeLimit) $ pushTo (getManager pool n) c
+putBackToPool pool c = do
+  l <- get' (rank c)
+  when (0 /= l) $ do let n = realLengthOfStack (lits c) - 3
+                     when (n <= storeLimit) $ pushTo (getManager pool n) c

--- a/src/SAT/Mios/Glucose.hs
+++ b/src/SAT/Mios/Glucose.hs
@@ -24,6 +24,7 @@ import SAT.Mios.Types
 import SAT.Mios.Clause
 import SAT.Mios.Solver
 
+-- | returns a POSIVITE value
 {-# INLINABLE lbdOf #-}
 lbdOf :: Solver -> Stack -> IO Int
 lbdOf Solver{..} vec = do

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -547,7 +547,7 @@ sortClauses s cm = do
                   let d =if | r < 0  -> 0
                             | a < at -> rankMax
                             | otherwise ->  min rankMax r                -- rank can be one
-                  when (r < 0) $ modify' (rank c) negate
+                  when (r < 0) $ set' (rank c) (negate r)
                   setNth keys i $ shiftL d shiftLBD + shiftL (scaleAct a) indexWidth + i
         assignKey (i + 1)
 {-

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -547,7 +547,7 @@ sortClauses s cm = do
                   let d =if | r < 0  -> 0
                             | a < at -> rankMax
                             | otherwise ->  min rankMax r                -- rank can be one
-                  when (r < 0) $ set' (rank c) (negate r)
+                  when (r < 0) $ modify' (rank c) negate
                   setNth keys i $ shiftL d shiftLBD + shiftL (scaleAct a) indexWidth + i
         assignKey (i + 1)
 {-

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -813,7 +813,7 @@ solve s@Solver{..} assumps = do
     then return False
     else do set' rootLevel =<< decisionLevel s
             -- SOLVE:
-            let useLuby = False -- True
+            let useLuby = False
                 -- nv = logBase 2 $ fromIntegral nVars
                 steps = 100 {- 10 * nv -}  :: Double
                 nk = 2 {- + 0.1 * nv -} :: Double

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -510,15 +510,17 @@ indexMax = 2 ^ indexWidth - 1 -- 2^6 G = 64G
 
 -- | sort clauses (good to bad) by using a 'proxy' @Vec Int64@ that holds weighted index.
 sortClauses :: Solver -> ClauseExtManager -> IO ()
-sortClauses Solver{..} cm = do
+sortClauses s cm = do
   n <- get' cm
   -- assert (n < indexMax)
   vec <- getClauseVector cm
   bvec <- getKeyVector cm
   keys <- (newVec n 0 :: IO (Vec Int))
-  at <- (0.1 *) . (/ fromIntegral n) <$> get' claInc -- activity threshold
+  at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
   let !shiftLBD = activityWidth + indexWidth
+      !rs = reason s
+      !tr = trail s
       scaleAct :: Double -> Int
       scaleAct x
         | x < 1e-20 = activityMax
@@ -527,10 +529,8 @@ sortClauses Solver{..} cm = do
       flipLocked :: Int -> IO ()
       flipLocked ((0 <) -> False) = return ()
       flipLocked !i = do
-        c <- getNth reason i
-        when (c /= NullClause) $ do
-          x <- get' (rank c)
-          when (0 < x) $ set' (rank c) (negate x)
+        c <- getNth rs . lit2var =<< getNth tr i
+        when (c /= NullClause) $ modify' (rank c) negate
         flipLocked $ i - 1
       -- returns the number of clauses that should be kept.
       assignKey :: Int -> IO ()
@@ -543,6 +543,7 @@ sortClauses Solver{..} cm = do
           else do a <- get' (activity c)               -- Second one... based on LBD
                   r <- get' (rank c)
 --                  l <- locked s c
+--                  when (l && 0 <= r) $ error (show (l, r))
                   let d =if | r < 0  -> 0
                             | a < at -> rankMax
                             | otherwise ->  min rankMax r                -- rank can be one
@@ -563,7 +564,7 @@ sortClauses Solver{..} cm = do
                                  setNth keys i $ shiftL rankMax shiftLBD + shiftL v indexWidth + i
                                  assignKey (i + 1) nr (nb + 1)
 -}
-  flipLocked nVars -- =<< get' (trail s)
+  flipLocked =<< get' (trail s)
   assignKey 0
   let limit = div n 2
   -- 2: sort keyVector

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -518,11 +518,20 @@ sortClauses s cm = do
   keys <- (newVec n 0 :: IO (Vec Int))
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
-  let shiftLBD = activityWidth + indexWidth
+  let !shiftLBD = activityWidth + indexWidth
+      !rs = reason s
+      !tr = trail s
       scaleAct :: Double -> Int
       scaleAct x
         | x < 1e-20 = activityMax
         | otherwise = activityMax * floor (1 - logBase 10 (x * 1e20) / 40)
+      -- mark locked clauses
+      flipLocked :: Int -> IO ()
+      flipLocked ((0 <) -> False) = return ()
+      flipLocked !i = do
+        c <- getNth rs . lit2var =<< getNth tr i
+        when (c /= NullClause) $ modify' (rank c) negate
+        flipLocked $ i - 1
       -- returns the number of clauses that should be kept.
       assignKey :: Int -> IO ()
       assignKey ((< n) -> False) = return ()
@@ -533,10 +542,12 @@ sortClauses s cm = do
           then do setNth keys i $ shiftL 1 indexWidth + i
           else do a <- get' (activity c)               -- Second one... based on LBD
                   r <- get' (rank c)
-                  l <- locked s c
-                  let d =if | l -> 0
+--                  l <- locked s c
+--                  when (l && 0 <= r) $ error (show (l, r))
+                  let d =if | r < 0  -> 0
                             | a < at -> rankMax
                             | otherwise ->  min rankMax r                -- rank can be one
+                  when (r < 0) $ modify' (rank c) negate
                   setNth keys i $ shiftL d shiftLBD + shiftL (scaleAct a) indexWidth + i
         assignKey (i + 1)
 {-
@@ -553,6 +564,7 @@ sortClauses s cm = do
                                  setNth keys i $ shiftL rankMax shiftLBD + shiftL v indexWidth + i
                                  assignKey (i + 1) nr (nb + 1)
 -}
+  flipLocked =<< get' (trail s)
   assignKey 0
   let limit = div n 2
   -- 2: sort keyVector


### PR DESCRIPTION
### objective
- [x] shrink clause size by dropping `leant`; `rank == 0` can use to indicate that it isn't a learnt.
- [x] use `rank` as the cache of `locked`; a minus value can use to indicate it. **NG**
- [x] reimplement `reduceDB` and `sortClauses` **No room to improve**

switched to the formal (but slightly modified) SAT-Competition main track benchmark suit.