### PR TITLE
Biclause optimization

### DIFF
--- a/mios.cabal
+++ b/mios.cabal
@@ -82,7 +82,7 @@ library
   else
     ghc-options:	-O2 -funbox-strict-fields -msse2 -fwarn-missing-signatures
 
-executable mios-52
+executable mios-48
   hs-source-dirs:	app
   main-is:              mios.hs
   if flag(prof)
@@ -97,7 +97,7 @@ executable mios-52
   else
     ghc-options:	-O2 -funbox-strict-fields -msse2 -rtsopts -fwarn-missing-signatures
 
-executable mios-52-prof
+executable mios-48-prof
   hs-source-dirs:	app
   main-is:              mios.hs
   if flag(prof)

--- a/mios.cabal
+++ b/mios.cabal
@@ -29,10 +29,6 @@ Flag llvm
   Description:	        Compile with llvm
   Default:	        False
 
-Flag lib
-  Description:	        Build the solver library
-  Default:	        False
-
 Flag prof
   Description:	        Build the profiler
   Default:	        False
@@ -46,11 +42,7 @@ Flag utils
   Default:	        False
 
 library
-  hs-source-dirs:	.
-  if flag(lib)
-    buildable:	        True
-  else
-    buildable:	        False
+  hs-source-dirs:	src
   default-language:	Haskell2010
   default-extensions:   Strict
   other-extensions:	    BangPatterns
@@ -71,10 +63,11 @@ library
                         SAT.Mios.Clause
                         SAT.Mios.ClauseManager
                         SAT.Mios.ClausePool
-                        SAT.Mios.Vec
+                        SAT.Mios.Glucose
                         SAT.Mios.Main
                         SAT.Mios.OptionParser
                         SAT.Mios.Solver
+                        SAT.Mios.Vec
                         SAT.Mios.Types
                         SAT.Mios.Validator
                         SAT.Mios.Util.DIMACS.MinisatReader
@@ -85,87 +78,51 @@ library
                         SAT.Mios
   build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
   if flag(llvm)
-    ghc-options:	-O2 -ignore-asserts -funbox-strict-fields -fllvm -optlo-O2 -optlc-O2
+    ghc-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -optlc-O3 -fwarn-missing-signatures
   else
-    ghc-options:	-O2 -ignore-asserts -funbox-strict-fields
+    ghc-options:	-O2 -funbox-strict-fields -msse2 -fwarn-missing-signatures
 
-executable mios-WIP
-  hs-source-dirs:	src app
+executable mios-52
+  hs-source-dirs:	app
   main-is:              mios.hs
   if flag(prof)
     buildable:	        False
   else
     buildable:	        True
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
+  default-extensions:   Strict
+  build-depends:        base, mios
   if flag(llvm)
     ghc-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -optlc-O3 -rtsopts -fwarn-missing-signatures
   else
     ghc-options:	-O2 -funbox-strict-fields -msse2 -rtsopts -fwarn-missing-signatures
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.ClausePool
-                        SAT.Mios.Glucose
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
 
-executable mios-WIP-prof
-  hs-source-dirs:	src app
+executable mios-52-prof
+  hs-source-dirs:	app
   main-is:              mios.hs
   if flag(prof)
     buildable:	        True
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
+  default-extensions:   Strict
+  build-depends:        base, mios
   if flag(llvm)
     ghc-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -prof -fprof-auto -rtsopts -ddump-simpl
   else
     ghc-options:	-O2 -funbox-strict-fields -prof -fprof-auto -rtsopts -ddump-simpl
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.ClausePool
-                        SAT.Mios.Glucose
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
 
 executable cnf-stat
-  hs-source-dirs:	src utils
+  hs-source-dirs:	utils
   main-is:              cnf-stat.hs
   if flag(utils)
     buildable:	        True
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.ClausePool
-                        SAT.Mios.Glucose
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mios-mc
   hs-source-dirs:	MultiConflict app
@@ -175,22 +132,12 @@ executable mios-mc
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
   if flag(llvm)
     ghc-options:	-O2 -ignore-asserts -funbox-strict-fields -fllvm -optlo-O2 -optlc-O2
   else
     ghc-options:	-O2 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
 
 executable mios-mc-prof
   hs-source-dirs:	MultiConflict app
@@ -200,19 +147,9 @@ executable mios-mc-prof
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O2 -ignore-asserts -funbox-strict-fields -prof -fprof-auto
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O2 -ignore-asserts -funbox-strict-fields -prof -fprof-auto
 
 executable mc-dump2csv
   hs-source-dirs:	MultiConflict
@@ -222,13 +159,9 @@ executable mc-dump2csv
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-averagecsv
   hs-source-dirs:	MultiConflict
@@ -238,13 +171,9 @@ executable mc-averagecsv
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-summary
   hs-source-dirs:	MultiConflict
@@ -254,13 +183,9 @@ executable mc-summary
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-stat2csv
   hs-source-dirs:	MultiConflict
@@ -270,13 +195,9 @@ executable mc-stat2csv
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.11, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-pickup
   hs-source-dirs:	MultiConflict
@@ -286,13 +207,9 @@ executable mc-pickup
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-numbers
   hs-source-dirs:	MultiConflict
@@ -302,10 +219,6 @@ executable mc-numbers
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields

--- a/mios.cabal
+++ b/mios.cabal
@@ -89,7 +89,7 @@ library
   else
     ghc-options:	-O2 -ignore-asserts -funbox-strict-fields
 
-executable mios-WIP
+executable mios-48
   hs-source-dirs:	src app
   main-is:              mios.hs
   if flag(prof)
@@ -116,7 +116,7 @@ executable mios-WIP
                         SAT.Mios.Vec
                         SAT.Mios
 
-executable mios-WIP-prof
+executable mios-48-prof
   hs-source-dirs:	src app
   main-is:              mios.hs
   if flag(prof)

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -48,7 +48,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.5.0WIP #52fix-bugs"
+versionId = "mios-1.5.0WIP #52"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -48,7 +48,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.5.0WIP #52"
+versionId = "mios-1.5.0WIP #52 #48"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -48,7 +48,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.5.0WIP"
+versionId = "mios-1.5.0WIP #52fix-bugs"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -48,7 +48,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.5.0WIP"
+versionId = "mios-1.5.0WIP #48"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios/Clause.hs
+++ b/src/SAT/Mios/Clause.hs
@@ -108,7 +108,7 @@ instance StackFamily Clause Lit where
 newClauseFromStack :: Bool -> Stack -> IO Clause
 newClauseFromStack l vec = do
   n <- get' vec
-  if n == 2 && False
+  if n == 2
     then do BiClause <$> getNth vec 1 <*> getNth vec 2
     else do v <- newStack n
             let loop ((<= n) -> False) = return ()

--- a/src/SAT/Mios/Clause.hs
+++ b/src/SAT/Mios/Clause.hs
@@ -108,7 +108,7 @@ instance StackFamily Clause Lit where
 newClauseFromStack :: Bool -> Stack -> IO Clause
 newClauseFromStack l vec = do
   n <- get' vec
-  if n == 2
+  if n == -2
     then do BiClause <$> getNth vec 1 <*> getNth vec 2
     else do v <- newStack n
             let loop ((<= n) -> False) = return ()

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -258,6 +258,7 @@ instance VecFamily ClauseExtManager C.Clause where
   setNth = error "no setNth method for ClauseExtManager"
   {-# SPECIALIZE INLINE reset :: ClauseExtManager -> IO () #-}
   reset m = set' (_nActives m) 0
+  asList m = take <$> get' m <*> (asList =<< getClauseVector m)
 {-
   dump mes ClauseExtManager{..} = do
     n <- get' _nActives

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -287,7 +287,8 @@ analyze s@Solver{..} confl = do
   loopOnLits 2 2                -- the first literal is specail
   -- glucose heuristics
   nld <- get' an'lastDL
-  r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
+  -- r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
+  r <- lbdOf s litsLearnt
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
@@ -295,8 +296,8 @@ analyze s@Solver{..} confl = do
                           case rc of
                             -- BiClause{} -> varBumpActivity s v
                             Clause{..} -> do
-                              r' <- get' rc
-                              when (r < r') $ varBumpActivity s v
+                              r' <- get' rank -- get' rc
+                              when (r' < r) $ varBumpActivity s v
                             _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -788,7 +788,7 @@ search s@Solver{..} nOfConflicts = do
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:
-            when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
+            -- when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
             k1 <- get' learnts
             k2 <- nAssigns s
             when (k1 - k2 >= nOfLearnts) $ do   -- This is a cheap check.

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -62,7 +62,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       print (l1, l2)
+       -- print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
        -- subsumeAll s learnts c
@@ -170,7 +170,7 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
-                putStrLn ("bump " ++ show v)
+                -- putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -228,7 +228,7 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
-                putStrLn ("bump " ++ show v)
+                -- putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -296,7 +296,7 @@ analyze s@Solver{..} confl = do
                           case rc of
                             Clause{..} -> do
                               r' <- get' rc
-                              when (2 < r' && r < r') $ varBumpActivity s v >> putStrLn ("bump loopOnLastDL" ++ show v)
+                              when (2 < r' && r < r') $ varBumpActivity s v -- >> putStrLn ("bump loopOnLastDL" ++ show v)
                             _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
@@ -483,13 +483,13 @@ propagate s@Solver{..} = do
                          BiClause {} -> do qc <- asList qq; return (2, sort qc)
                          _ -> return (0, [])
             (blocker :: Lit) <- getNth bvec i        -- Try to avoid inspecting the clause:
-            when (qn == 2) $ do putStr $ show qc ++ ":" ++ show (p, blocker) ++ " => "
+            -- when (qn == 2) $ do putStr $ show qc ++ ":" ++ show (p, blocker) ++ " => "
             bv <- if blocker == 0 then return LiftedF else valueLit s blocker
             if bv == LiftedT
               then do unless (i == j) $ do (c :: Clause) <- getNth cvec i
                                            setNth cvec j c
                                            setNth bvec j blocker
-                      when (qn == 2) $ print (falseLit, i, qc, LiftedT, i - j, blocker)
+                      -- when (qn == 2) $ print (falseLit, i, qc, LiftedT, i - j, blocker)
                       forClause (i + 1) (j + 1)
               else do                               -- Make sure the false literal is data[1]:
                   (c :: Clause) <- getNth cvec i
@@ -499,15 +499,15 @@ propagate s@Solver{..} = do
                       sv <- valueLit s second
                       setNth cvec j c >> setNth bvec j l1
                       case sv of
-                        LiftedT -> do print (falseLit, i, qc, sv, i - j, l1)
+                        LiftedT -> do -- print (falseLit, i, qc, sv, i - j, l1)
                                       forClause (i + 1) (j + 1)
                         LBottom -> do setNth bvec j second
-                                      print (falseLit, i, qc, sv, i - j, second)
+                                      -- print (falseLit, i, qc, sv, i - j, second)
                                       unsafeEnqueue s second c
                                       -- putStrLn $ "Biclause propagation from: " ++ show p ++ " to " ++ show second ++ " by " ++ show c
                                       forClause (i + 1) (j + 1)
                         LiftedF -> do setNth bvec j second
-                                      print (falseLit, i, qc, sv, i - j, second)
+                                      -- print (falseLit, i, qc, sv, i - j, second)
                                       ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
                                       -- putStrLn $ "Biclause conflict with: " ++ show p ++ " and " ++ show second ++ " by " ++ show c
                                       set' qHead =<< get' trail
@@ -904,7 +904,7 @@ solve s@Solver{..} assumps = do
 unsafeEnqueue :: Solver -> Lit -> Clause -> IO ()
 unsafeEnqueue s@Solver{..} p from = do
   c <- asList from
-  putStrLn $ "Unsafe Enqueue: " ++ show (p, sort c)
+  -- putStrLn $ "Unsafe Enqueue: " ++ show (p, sort c)
   let v = lit2var p
   setNth assigns v $ lit2lbool p
   setNth level v =<< decisionLevel s

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -62,10 +62,10 @@ newLearntClause s@Solver{..} ps = do
        l2 <- getNth ps 2
        let c = BiClause l1 l2
        -- inplaceSubsume s clauses c
-       subsumeAll s 1 c
-       subsumeAll s 2 c
-       pushTo learnts c
-       -- pushTo clauses c
+       -- subsumeAll s 1 c
+       -- subsumeAll s 2 c
+       -- pushTo learnts c
+       pushTo clauses c
        pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
        pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
        unsafeEnqueue s l1 c
@@ -966,6 +966,14 @@ subsumeAll s kin (BiClause l1 l2) = do
               then removeWatch s c >> loop (i + 1) j
               else do unless (i == j) $ setNth cvec j c >> setNth bvec j b
                       loop (i + 1) (j + 1)
+          BiClause x y | lit2var x == lit2var l1 -> do
+                           -- print ((x,y), (l1, l2))
+                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                           loop (i + 1) (j + 1)
+          BiClause x y | lit2var x == lit2var l2 -> do
+                           -- print ((x,y), (l2, l1))
+                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                           loop (i + 1) (j + 1)
           _ -> do unless (i == j) $ setNth cvec j c >> setNth bvec j b
                   loop (i + 1) (j + 1)
   n' <- loop start start

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -61,6 +61,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
+       print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
        -- unbumpSubsumables learnts c

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -61,7 +61,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       pushTo clauses c
+       inplaceSubsume s learnts c
        pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
        pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
        unsafeEnqueue s l1 c
@@ -900,3 +900,55 @@ luby y x_ = loop 1 0
     loop2 x sz sq
       | sz - 1 == x = y ** fromIntegral sq
       | otherwise   = let s = div (sz - 1) 2 in loop2 (mod x s) s (sq - 1)
+
+inplaceSubsume :: Solver -> ClauseExtManager -> Clause -> IO Bool
+inplaceSubsume s clss b@(BiClause l1 l2) = do
+  n <- get' clss
+  cvec <- getClauseVector clss
+  bvec <- getKeyVector clss
+  let loop ((< n) -> False) = return False
+      loop i = do
+        c <- getNth cvec i
+        case c :: Clause of
+          Clause{..} -> do
+            x <- getNth lits 1
+            y <- getNth lits 2
+            if (x == l1 && y == l2) || (x == l2 && y == l1)
+              then do removeWatch s c
+                      reset (watches s)
+                      setNth cvec i b
+                      setNth bvec i l2
+                      return True
+              else loop (i + 1)
+          _ -> loop (i + 1)
+  loop (div n 2)
+
+-- | purges all clauses which the biclause can subsume
+subsumeAll :: Solver -> ClauseExtManager -> Clause -> IO Bool
+subsumeAll s clss (BiClause l1 l2) = do
+  n <- get' clss
+  cvec <- getClauseVector clss
+  bvec <- getKeyVector clss
+  let loop ((< n) -> False) j = return j
+      loop i j = do
+        c <- getNth cvec i
+        b <- getNth bvec i
+        case c :: Clause of
+          Clause{..} -> do
+            let check :: Lit -> Lit -> Int -> IO Bool
+                check _ 0 0 _ = return True
+                check _ _ 0 = return False
+                check a b i = do
+                  l <- getNth lits i
+                  check (if l == a then 0 else a) (if l == b then 0 else b) (i - 1)
+            y <- check l1 l2 =<< get' c
+            if y                -- subsumed
+              then removeWatch s c >> loop (i + 1) j
+              else do unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                      loop (i + 1) (j + 1)
+          _ -> do unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                  loop (i + 1) (j + 1)
+  n' <- loop 0 0
+  if n' < n
+    then shrinkBy clss (n - n') >> reset (watches s) >> return True
+    else return False

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -61,7 +61,11 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       inplaceSubsume s learnts c
+       -- inplaceSubsume s clauses c
+       subsumeAll s 1 c
+       subsumeAll s 2 c
+       pushTo learnts c
+       -- pushTo clauses c
        pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
        pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
        unsafeEnqueue s l1 c
@@ -149,7 +153,7 @@ analyze s@Solver{..} confl = do
   dl <- decisionLevel s
   let
     loopOnClauseChain :: Clause -> Lit -> Int -> Int -> Int -> IO Int
-    loopOnClauseChain NullClause lit _ _ _ = error $ "strange analyze loop: " ++ show lit
+    loopOnClauseChain NullClause lit _ _ _ = error $ "strange analyze loop: " ++ show (lit, confl)
     loopOnClauseChain c@(BiClause l1 l2) p ti bl pathC = do -- p : literal, ti = trail index, bl = backtrack level
       let
         loopOnLiterals :: Lit -> Int -> Int -> IO (Int, Int)
@@ -930,12 +934,14 @@ inplaceSubsume s clss b@(BiClause l1 l2) = do
                       return True
               else loop (i + 1)
           _ -> loop (i + 1)
-  loop (div n 2)
+  loop 0
 
 -- | purges all clauses which the biclause can subsume
-subsumeAll :: Solver -> ClauseExtManager -> Clause -> IO Bool
-subsumeAll s clss (BiClause l1 l2) = do
+subsumeAll :: Solver -> Int -> Clause -> IO Bool
+subsumeAll s kin (BiClause l1 l2) = do
+  let clss = if kin == 1 then clauses s else learnts s
   n <- get' clss
+  let start = if kin == 1 then 0 else div n 2
   cvec <- getClauseVector clss
   bvec <- getKeyVector clss
   let loop ((< n) -> False) j = return j
@@ -944,20 +950,25 @@ subsumeAll s clss (BiClause l1 l2) = do
         b <- getNth bvec i
         case c :: Clause of
           Clause{..} -> do
-            let check :: Lit -> Lit -> Int -> IO Bool
-                check 0 0 _ = return True
+            let check :: Bool -> Bool -> Int -> IO Bool
+                check True True _ = return True
                 check _ _ 0 = return False
-                check a b i = do
-                  l <- getNth lits i
-                  check (if l == a then 0 else a) (if l == b then 0 else b) (i - 1)
-            y <- check l1 l2 =<< get' c
+                check a b i = do l <- getNth lits i
+                                 if -l == l1 || -1 == l2
+                                   then return False
+                                   else check (l == l1 || a) (l == l2 || b) (i - 1)
+            y <- check False False =<< get' c
+            -- l <- locked s c
+            -- when (l && y) $ error "AAAA"
+            -- locked s c ; interestingly, a clause that can be subsumed is never used as reason.
+            -- The literal which level is highest in a learnt has been unassigned by cancelUntil.
             if y                -- subsumed
               then removeWatch s c >> loop (i + 1) j
               else do unless (i == j) $ setNth cvec j c >> setNth bvec j b
                       loop (i + 1) (j + 1)
           _ -> do unless (i == j) $ setNth cvec j c >> setNth bvec j b
                   loop (i + 1) (j + 1)
-  n' <- loop 0 0
+  n' <- loop start start
   if n' < n
     then shrinkBy clss (n - n') >> reset (watches s) >> return True
     else return False

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -28,6 +28,10 @@ import SAT.Mios.Glucose
 -- | #114: __RemoveWatch__
 {-# INLINABLE removeWatch #-}
 removeWatch :: Solver -> Clause -> IO ()
+removeWatch Solver{..} c@(BiClause l1 l2) = do
+  markClause (getNthWatcher watches (negateLit l1)) c
+  markClause (getNthWatcher watches (negateLit l2)) c
+
 removeWatch Solver{..} c = do
   let lstack = lits c
   l1 <- negateLit <$> getNth lstack 1
@@ -601,15 +605,17 @@ sortClauses s cm limit = do
       assignKey ((< n) -> False) = return ()
       assignKey i = do
         c <- getNth vec i
-        k <- get' c
-        if k == 2                  -- Main criteria. Like in MiniSat we keep all binary clauses
-          then do setNth keys i $ shiftL 1 indexWidth + i
-          else do a <- get' (activity c)               -- Second one... based on LBD
+        case c of
+          -- Main criteria. Like in MiniSat we keep all binary clauses
+          BiClause _ _ -> setNth keys i $ shiftL 1 indexWidth + i
+          _ -> do -- k <- get' c
+                  -- when (k == 2) $ error "strange k"
+                  a <- get' (activity c)                 -- Second one... based on LBD
                   r <- get' (rank c)
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax
-                            | otherwise ->  min rankMax r                -- rank can be one
+                            | otherwise -> min rankMax r -- rank can be one
                   setNth keys i $ shiftL d shiftLBD + shiftL (scaleAct a) indexWidth + i
         assignKey (i + 1)
   assignKey 0
@@ -691,11 +697,14 @@ simplifyDB s@Solver{..} = do
                   loopOnVector ((< n') -> False) j = shrinkBy mgr (n' - j)
                   loopOnVector i j = do
                         c <- getNth vec' i
-                        l <- locked s c
-                        r <- if l then return False else simplify s c
-                        if r
-                          then removeWatch s c >> loopOnVector (i + 1) j
-                          else unless (i == j) (setNth vec' j c) >> loopOnVector (i + 1) (j + 1)
+                        case c of
+                          BiClause{} -> unless (i == j) (setNth vec' j c) >> loopOnVector (i + 1) (j + 1)
+                          _ -> do
+                            l <- locked s c
+                            r <- if l then return False else simplify s c
+                            if r
+                              then removeWatch s c >> loopOnVector (i + 1) j
+                              else unless (i == j) (setNth vec' j c) >> loopOnVector (i + 1) (j + 1)
                 loopOnVector 0 0
             for clauses
             for learnts

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -50,9 +50,17 @@ newLearntClause s@Solver{..} ps = do
     -- Since this solver must generate only healthy learnt clauses, we need not to run misc check in 'newClause'
     k <- get' ps
     case k of
-     1 -> do
+     1 -> do                    -- a fact
        l <- getNth ps 1
        unsafeEnqueue s l NullClause
+     2 -> do                    -- biclause
+       l1 <- getNth ps 1
+       l2 <- getNth ps 2
+       let c = BiClause l1 l2
+       pushTo clauses c
+       pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
+       pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
+       unsafeEnqueue s l1 c
      _ -> do
        -- allocate clause:
        c <- makeClauseFromStack clsPool ps --  newClauseFromStack True ps
@@ -137,6 +145,67 @@ analyze s@Solver{..} confl = do
   dl <- decisionLevel s
   let
     loopOnClauseChain :: Clause -> Lit -> Int -> Int -> Int -> IO Int
+    loopOnClauseChain NullClause lit _ _ _ = error $ "strange analyze loop: " ++ show lit
+    loopOnClauseChain c@(BiClause l1 l2) p ti bl pathC = do -- p : literal, ti = trail index, bl = backtrack level
+      putStrLn $ "analyze on biclause: " ++ show (c, confl, confl == c)
+      let
+        loopOnLiterals :: Lit -> Int -> Int -> IO (Int, Int)
+        loopOnLiterals q b pc = do
+          let v = lit2var q
+          sn <- getNth an'seen v
+          l <- getNth level v
+          if sn == 0 && 0 < l
+            then do
+                varBumpActivity s v
+                setNth an'seen v 1
+                print v
+                if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
+                  then do
+                      -- glucose heuristics
+                      r <- getNth reason v
+                      case r of
+                        NullClause   -> return () -- setNth an'seen v 0
+                        BiClause _ _ -> return ()
+                        _            -> do
+                          ra <- get' (rank r)
+                          when (0 /= ra) $ pushTo an'lastDL q
+                      -- end of glucose heuristics
+                      -- loopOnLiterals (j + 1) b (pc + 1)
+                      return (b, pc + 1)
+                  else pushTo litsLearnt q >> return (max b l, pc) -- loopOnLiterals (j + 1) (max b l) pc
+            else return (b, pc) -- loopOnLiterals (j + 1) b pc
+      r1 <- getNth reason (lit2var l1)
+--      r2 <- getNth reason (lit2var l2)
+--      v1 <- valueLit s l1
+--      v2 <- valueLit s l2
+      when ((c == confl) /= (p == LBottom)) $ error "!!!@@@@@@@@@@@@@@@22"
+      -- Two posibility:
+      -- * this biclause @b@ is used on the depdendency tree; target should be the literal which reason is NOT @b@.
+      -- * this biclause @b@ is the conflicting clause; @b@ is not stored in reason; target is the literal which is assigned.
+      -- print (r1 == c, r2 == c, r1 == NullClause, r2 == NullClause) 
+      (b', pathC') <- if p == LBottom
+                      then do (b1, pathC1) <- loopOnLiterals l1 bl pathC
+                              loopOnLiterals l2 b1 pathC1
+                      else loopOnLiterals (if r1 == c then l2 else l1) bl pathC
+{-
+      let target = if r1 /= c && r2 /= c
+                   then if v1 /= LBottom then 1 else 2 -- if r1 == NullClause then 2 else 1
+                   else if r1 == c then 2 else 1
+      (b', pathC') <- loopOnLiterals target bl pathC
+-}
+      let
+        -- select next clause to look at
+        nextPickedUpLit :: Int -> IO Int
+        nextPickedUpLit i = do x <- getNth an'seen . lit2var =<< getNth trail i
+                               if x == 0 then nextPickedUpLit (i - 1) else return (i - 1)
+      ti' <- nextPickedUpLit (ti + 1)
+      nextP <- getNth trail (ti' + 1)
+      let nextV = lit2var nextP
+      confl' <- getNth reason nextV
+      setNth an'seen nextV 0
+      if 1 < pathC'
+        then loopOnClauseChain confl' nextP (ti' - 1) b' (pathC' - 1)
+        else setNth litsLearnt 1 (negateLit nextP) >> return b'
     loopOnClauseChain c p ti bl pathC = do -- p : literal, ti = trail index, bl = backtrack level
       d <- get' (rank c)
       when (0 /= d) $ claBumpActivity s c
@@ -161,13 +230,17 @@ analyze s@Solver{..} confl = do
             then do
                 varBumpActivity s v
                 setNth an'seen v 1
+                when (sc == 2) (print v)
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
                       -- glucose heuristics
                       r <- getNth reason v
-                      when (r /= NullClause) $ do
-                        ra <- get' (rank r)
-                        when (0 /= ra) $ pushTo an'lastDL q
+                      case r of
+                        NullClause   -> return ()
+                        BiClause _ _ -> return ()
+                        _            -> do
+                          ra <- get' (rank r)
+                          when (0 /= ra) $ pushTo an'lastDL q
                       -- end of glucose heuristics
                       loopOnLiterals (j + 1) b (pc + 1)
                   else pushTo litsLearnt q >> loopOnLiterals (j + 1) (max b l) pc
@@ -188,6 +261,7 @@ analyze s@Solver{..} confl = do
         else setNth litsLearnt 1 (negateLit nextP) >> return b'
   ti <- subtract 1 <$> get' trail
   levelToReturn <- loopOnClauseChain confl bottomLit ti 0 0
+  putStrLn "done"
   -- Simplify phase (implemented only @expensive_ccmin@ path)
   n <- get' litsLearnt
   reset an'stack           -- analyze_stack.clear();
@@ -262,37 +336,40 @@ analyzeRemovable Solver{..} p minLevel = do
             sl <- lastOf an'stack
             popFrom an'stack             -- analyze_stack.pop();
             c <- getNth reason (lit2var sl) -- getRoot sl
-            nl <- get' c
-            let
-              lstack = lits c
-              loopOnLit :: Int -> IO Bool -- loopOnLit (int i = 1; i < c.size(); i++){
-              loopOnLit ((<= nl) -> False) = loopOnStack
-              loopOnLit i = do
-                p' <- getNth lstack i              -- valid range is [1 .. nl]
-                let v' = lit2var p'
-                l' <- getNth level v'
-                c1 <- (1 /=) <$> getNth an'seen v'
-                if c1 && (0 /= l')   -- if (!analyze_seen[var(p)] && level[var(p)] != 0){
-                  then do
-                      c3 <- (NullClause /=) <$> getNth reason v'
-                      if c3 && testBit minLevel (l' .&. 31) -- if (reason[var(p)] != GClause_NULL && ((1 << (level[var(p)] & 31)) & min_level) != 0){
-                        then do
-                            setNth an'seen v' 1   -- analyze_seen[var(p)] = 1;
-                            pushTo an'stack p'    -- analyze_stack.push(p);
-                            pushTo an'toClear p'  -- analyze_toclear.push(p);
-                            loopOnLit $ i + 1
-                        else do
-                            -- for (int j = top; j < analyze_toclear.size(); j++) analyze_seen[var(analyze_toclear[j])] = 0;
-                            top' <- get' an'toClear
-                            let clearAll :: Int -> IO ()
-                                clearAll ((<= top') -> False) = return ()
-                                clearAll j = do x <- getNth an'toClear j; setNth an'seen (lit2var x) 0; clearAll (j + 1)
-                            clearAll $ top + 1
-                            -- analyze_toclear.shrink(analyze_toclear.size() - top); note: shrink n == repeat n pop
-                            shrinkBy an'toClear $ top' - top
-                            return False
-                  else loopOnLit $ i + 1
-            loopOnLit 2
+            case c of
+              BiClause l1 l2 -> do return False
+              _ -> do
+                nl <- get' c
+                let
+                  lstack = lits c
+                  loopOnLit :: Int -> IO Bool -- loopOnLit (int i = 1; i < c.size(); i++){
+                  loopOnLit ((<= nl) -> False) = loopOnStack
+                  loopOnLit i = do
+                    p' <- getNth lstack i              -- valid range is [1 .. nl]
+                    let v' = lit2var p'
+                    l' <- getNth level v'
+                    c1 <- (1 /=) <$> getNth an'seen v'
+                    if c1 && (0 /= l')   -- if (!analyze_seen[var(p)] && level[var(p)] != 0){
+                      then do
+                          c3 <- (NullClause /=) <$> getNth reason v'
+                          if c3 && testBit minLevel (l' .&. 31) -- if (reason[var(p)] != GClause_NULL && ((1 << (level[var(p)] & 31)) & min_level) != 0){
+                            then do
+                                setNth an'seen v' 1   -- analyze_seen[var(p)] = 1;
+                                pushTo an'stack p'    -- analyze_stack.push(p);
+                                pushTo an'toClear p'  -- analyze_toclear.push(p);
+                                loopOnLit $ i + 1
+                            else do
+                                -- for (int j = top; j < analyze_toclear.size(); j++) analyze_seen[var(analyze_toclear[j])] = 0;
+                                top' <- get' an'toClear
+                                let clearAll :: Int -> IO ()
+                                    clearAll ((<= top') -> False) = return ()
+                                    clearAll j = do x <- getNth an'toClear j; setNth an'seen (lit2var x) 0; clearAll (j + 1)
+                                clearAll $ top + 1
+                                -- analyze_toclear.shrink(analyze_toclear.size() - top); note: shrink n == repeat n pop
+                                shrinkBy an'toClear $ top' - top
+                                return False
+                      else loopOnLit $ i + 1
+                loopOnLit 2
   loopOnStack
 
 -- | #114
@@ -389,42 +466,62 @@ propagate s@Solver{..} = do
                       forClause (i + 1) (j + 1)
               else do                               -- Make sure the false literal is data[1]:
                   (c :: Clause) <- getNth cvec i
-                  let !lstack = lits c
-                  tmp <- getNth lstack 1
-                  first <- if falseLit == tmp
-                           then do l2 <- getNth lstack 2
-                                   setNth lstack 2 tmp
-                                   setNth lstack 1 l2
-                                   return l2
-                           else return tmp
-                  fv <- valueLit s first
-                  if first /= blocker && fv == LiftedT
-                    then setNth cvec j c >> setNth bvec j first >> forClause (i + 1) (j + 1)
-                    else do cs <- get' c           -- Look for new watch:
-                            let newWatch :: Int -> IO LiftedBool
-                                newWatch ((<= cs) -> False) = do -- Did not find watch
-                                  setNth cvec j c
-                                  setNth bvec j first
-                                  if fv == LiftedF
-                                    then do ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
-                                            set' qHead =<< get' trail
-                                            copy (i + 1) (j + 1)
-                                            return LiftedF                 -- conflict
-                                    else do unsafeEnqueue s first c
-                                            return LBottom                 -- unit clause
-                                newWatch !k = do (l' :: Lit) <- getNth lstack k
-                                                 lv <- valueLit s l'
-                                                 if lv /= LiftedF
-                                                   then do setNth lstack 2 l'
-                                                           setNth lstack k falseLit
-                                                           pushClauseWithKey (getNthWatcher watches (negateLit l')) c first
-                                                           return LiftedT  -- find another watch
-                                                   else newWatch $! k + 1
-                            ret <- newWatch 3
-                            case ret of
-                              LiftedT -> forClause (i + 1) j               -- find another watch
-                              LBottom -> forClause (i + 1) (j + 1)         -- unit clause
-                              _       -> shrinkBy ws (i - j) >> return c   -- conflict
+                  case c of
+                    BiClause l1 l2 -> do
+                      let first = if l1 == falseLit then l1 else l2
+                      let second = if l1 == falseLit then l2 else l1
+                      ch <- valueLit s first
+                      bv' <- valueLit s blocker
+                      sv <- valueLit s second
+                      when (ch /= LiftedF) $ error $ "strange literal" ++ show ((blocker, bv'), l1, l2, (ch, sv))
+                      setNth cvec j c >> setNth bvec j l1
+                      case sv of
+                        LiftedT -> do forClause (i + 1) (j + 1)
+                        LBottom -> do unsafeEnqueue s second c
+                                      putStrLn $ "Biclause propagation from: " ++ show p ++ " to " ++ show second ++ " by " ++ show c
+                                      forClause (i + 1) (j + 1)
+                        LiftedF -> do ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
+                                      putStrLn $ "Biclause conflict with: " ++ show p ++ " and " ++ show second ++ " by " ++ show c
+                                      set' qHead =<< get' trail
+                                      copy (i + 1) (j + 1)
+                                      shrinkBy ws (i - j) >> return c
+                    _ -> do
+                      let !lstack = lits c
+                      tmp <- getNth lstack 1
+                      first <- if falseLit == tmp
+                               then do l2 <- getNth lstack 2
+                                       setNth lstack 2 tmp
+                                       setNth lstack 1 l2
+                                       return l2
+                               else return tmp
+                      fv <- valueLit s first
+                      if first /= blocker && fv == LiftedT
+                        then setNth cvec j c >> setNth bvec j first >> forClause (i + 1) (j + 1)
+                        else do cs <- get' c           -- Look for new watch:
+                                let newWatch :: Int -> IO LiftedBool
+                                    newWatch ((<= cs) -> False) = do -- Did not find watch
+                                      setNth cvec j c
+                                      setNth bvec j first
+                                      if fv == LiftedF
+                                        then do ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
+                                                set' qHead =<< get' trail
+                                                copy (i + 1) (j + 1)
+                                                return LiftedF                 -- conflict
+                                        else do unsafeEnqueue s first c
+                                                return LBottom                 -- unit clause
+                                    newWatch !k = do (l' :: Lit) <- getNth lstack k
+                                                     lv <- valueLit s l'
+                                                     if lv /= LiftedF
+                                                       then do setNth lstack 2 l'
+                                                               setNth lstack k falseLit
+                                                               pushClauseWithKey (getNthWatcher watches (negateLit l')) c first
+                                                               return LiftedT  -- find another watch
+                                                       else newWatch $! k + 1
+                                ret <- newWatch 3
+                                case ret of
+                                  LiftedT -> forClause (i + 1) j               -- find another watch
+                                  LBottom -> forClause (i + 1) (j + 1)         -- unit clause
+                                  _       -> shrinkBy ws (i - j) >> return c   -- conflict
       c <- forClause 0 0
       while c =<< ((<) <$> get' qHead <*> get' trail)
   while NullClause =<< ((<) <$> get' qHead <*> get' trail)

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -789,7 +789,7 @@ search s@Solver{..} nOfConflicts = do
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:
-            when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
+            -- when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
             k1 <- get' learnts
             k2 <- nAssigns s
             when (k1 - k2 >= nOfLearnts) $ do   -- This is a cheap check.

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -62,7 +62,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       print (l1, l2)
+       -- print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
        -- subsumeAll s learnts c
@@ -170,7 +170,7 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
-                putStrLn ("bump " ++ show v)
+                -- putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -228,7 +228,7 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
-                putStrLn ("bump " ++ show v)
+                -- putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -296,7 +296,7 @@ analyze s@Solver{..} confl = do
                           case rc of
                             Clause{..} -> do
                               r' <- get' rc
-                              when (2 < r' && r < r') $ varBumpActivity s v >> putStrLn ("bump loopOnLastDL" ++ show v)
+                              when (2 < r' && r < r') $ varBumpActivity s v -- >> putStrLn ("bump loopOnLastDL" ++ show v)
                             _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
@@ -483,13 +483,13 @@ propagate s@Solver{..} = do
                          BiClause {} -> do qc <- asList qq; return (2, sort qc)
                          _ -> return (0, [])
             (blocker :: Lit) <- getNth bvec i        -- Try to avoid inspecting the clause:
-            when (qn == 2) $ do putStr $ show qc ++ ":" ++ show (p, blocker) ++ " => "
+            -- when (qn == 2) $ do putStr $ show qc ++ ":" ++ show (p, blocker) ++ " => "
             bv <- if blocker == 0 then return LiftedF else valueLit s blocker
             if bv == LiftedT
               then do unless (i == j) $ do (c :: Clause) <- getNth cvec i
                                            setNth cvec j c
                                            setNth bvec j blocker
-                      when (qn == 2) $ print (falseLit, i, qc, LiftedT, i - j, blocker)
+                      -- when (qn == 2) $ print (falseLit, i, qc, LiftedT, i - j, blocker)
                       forClause (i + 1) (j + 1)
               else do                               -- Make sure the false literal is data[1]:
                   (c :: Clause) <- getNth cvec i
@@ -499,15 +499,15 @@ propagate s@Solver{..} = do
                       sv <- valueLit s second
                       setNth cvec j c >> setNth bvec j l1
                       case sv of
-                        LiftedT -> do print (falseLit, i, qc, sv, i - j, l1)
+                        LiftedT -> do -- print (falseLit, i, qc, sv, i - j, l1)
                                       forClause (i + 1) (j + 1)
                         LBottom -> do setNth bvec j second
-                                      print (falseLit, i, qc, sv, i - j, second)
+                                      -- print (falseLit, i, qc, sv, i - j, second)
                                       unsafeEnqueue s second c
                                       -- putStrLn $ "Biclause propagation from: " ++ show p ++ " to " ++ show second ++ " by " ++ show c
                                       forClause (i + 1) (j + 1)
                         LiftedF -> do setNth bvec j second
-                                      print (falseLit, i, qc, sv, i - j, second)
+                                      -- print (falseLit, i, qc, sv, i - j, second)
                                       ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
                                       -- putStrLn $ "Biclause conflict with: " ++ show p ++ " and " ++ show second ++ " by " ++ show c
                                       set' qHead =<< get' trail
@@ -903,7 +903,7 @@ solve s@Solver{..} assumps = do
 unsafeEnqueue :: Solver -> Lit -> Clause -> IO ()
 unsafeEnqueue s@Solver{..} p from = do
   c <- asList from
-  putStrLn $ "Unsafe Enqueue: " ++ show (p, sort c)
+  -- putStrLn $ "Unsafe Enqueue: " ++ show (p, sort c)
   let v = lit2var p
   setNth assigns v $ lit2lbool p
   setNth level v =<< decisionLevel s

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -690,14 +690,6 @@ simplifyDB s@Solver{..} = do
       if p /= NullClause
         then set' ok False >> return False
         else do
-            -- Clear watcher lists:
-            n <- get' trail
-            let loopOnLit ((< n) -> False) = return ()
-                loopOnLit i = do l <- getNth trail i
-                                 reset . getNthWatcher watches $ l
-                                 reset . getNthWatcher watches $ negateLit l
-                                 loopOnLit $ i + 1
-            loopOnLit 1
             -- Remove satisfied clauses:
             let
               for :: Int -> IO Bool

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -281,7 +281,8 @@ analyze s@Solver{..} confl = do
   loopOnLits 2 2                -- the first literal is specail
   -- UPDATEVARACTIVITY: glucose heuristics
   nld <- get' an'lastDL
-  r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
+  -- r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
+  r <- lbdOf s litsLearnt
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
@@ -289,8 +290,8 @@ analyze s@Solver{..} confl = do
                           case rc of
                             BiClause{} -> varBumpActivity s v
                             Clause{..} -> do
-                              r' <- get' rc
-                              when (r < r') $ varBumpActivity s v
+                              r' <- get' rank -- get' rc
+                              when (r' < r) $ varBumpActivity s v
                             _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -720,9 +720,9 @@ simplifyDB s@Solver{..} = do
                   loopOnVector ((< n') -> False) j = shrinkBy ptr (n' - j) >> return True
                   loopOnVector i j = do
                         c <- getNth vec' i
-                        l <- locked s c
+                        -- l <- locked s c
                         r <- simplify s c
-                        if not l && r
+                        if r -- not l && r
                           then removeWatch s c >> loopOnVector (i + 1) j
                           else setNth vec' j c >> loopOnVector (i + 1) (j + 1)
                 loopOnVector 0 0
@@ -796,7 +796,7 @@ search s@Solver{..} nOfConflicts = do
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:
-            when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
+            -- when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
             k1 <- get' learnts
             k2 <- nAssigns s
             when (k1 - k2 >= nOfLearnts) $ do   -- This is a cheap check.
@@ -825,6 +825,7 @@ search s@Solver{..} nOfConflicts = do
                        toggleAt ((<= nv) -> False) = return ()
                        toggleAt i = modifyNth phases toggle i >> toggleAt (i + 1)
                    toggleAt 1
+                   void $ simplifyDB s -- our simplifier cannot return @False@ here
                    incrementStat s NumOfRestart 1
                    return LBottom
              _ -> do

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -65,6 +65,7 @@ newLearntClause s@Solver{..} ps = do
        print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
+       -- subsumeAll s learnts c
        -- unbumpSubsumables learnts c
        -- unbumpSubsumees (getNthWatcher watches (negateLit l1)) c
        -- unbumpSubsumees (getNthWatcher watches (negateLit l2)) c
@@ -169,6 +170,7 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
+                putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -176,7 +178,7 @@ analyze s@Solver{..} confl = do
                       r <- getNth reason v
                       case r of
                         Clause{} -> do ra <- get' (rank r)
-                                       when (0 /= ra) $ pushTo an'lastDL q
+                                       when (2 < ra) $ pushTo an'lastDL q
                         _        -> return ()
                       -- end of glucose heuristics
                       return (b, pc + 1)
@@ -226,6 +228,7 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
+                putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -233,7 +236,7 @@ analyze s@Solver{..} confl = do
                       r <- getNth reason v
                       case r of
                         Clause{} -> do ra <- get' (rank r)
-                                       when (0 /= ra) $ pushTo an'lastDL q
+                                       when (2 < ra && 0 /= ra) $ pushTo an'lastDL q
                         _        -> return ()
                       -- end of glucose heuristics
                       loopOnLiterals (j + 1) b (pc + 1)
@@ -289,8 +292,12 @@ analyze s@Solver{..} confl = do
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
-                          r' <- get' =<< getNth reason v
-                          when (r < r') $ varBumpActivity s v
+                          rc <- getNth reason v
+                          case rc of
+                            Clause{..} -> do
+                              r' <- get' rc
+                              when (2 < r' && r < r') $ varBumpActivity s v >> putStrLn ("bump loopOnLastDL" ++ show v)
+                            _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL
@@ -471,12 +478,18 @@ propagate s@Solver{..} = do
       let forClause :: Int -> Int -> IO Clause
           forClause i@((< end) -> False) !j = shrinkBy ws (i - j) >> return confl
           forClause !i !j = do
+            qq <- getNth cvec i
+            (qn, qc) <- case qq of
+                         BiClause {} -> do qc <- asList qq; return (2, sort qc)
+                         _ -> return (0, [])
             (blocker :: Lit) <- getNth bvec i        -- Try to avoid inspecting the clause:
+            when (qn == 2) $ do putStr $ show qc ++ ":" ++ show (p, blocker) ++ " => "
             bv <- if blocker == 0 then return LiftedF else valueLit s blocker
             if bv == LiftedT
               then do unless (i == j) $ do (c :: Clause) <- getNth cvec i
                                            setNth cvec j c
                                            setNth bvec j blocker
+                      when (qn == 2) $ print (falseLit, i, qc, LiftedT, i - j, blocker)
                       forClause (i + 1) (j + 1)
               else do                               -- Make sure the false literal is data[1]:
                   (c :: Clause) <- getNth cvec i
@@ -485,18 +498,21 @@ propagate s@Solver{..} = do
                       let second = if l1 == falseLit then l2 else l1
                       sv <- valueLit s second
                       setNth cvec j c >> setNth bvec j l1
-                      x <- asList c
-                      print (i, sort x, sv)
                       case sv of
-                        LiftedT -> do forClause (i + 1) (j + 1)
-                        LBottom -> do unsafeEnqueue s second c
+                        LiftedT -> do print (falseLit, i, qc, sv, i - j, l1)
+                                      forClause (i + 1) (j + 1)
+                        LBottom -> do setNth bvec j second
+                                      print (falseLit, i, qc, sv, i - j, second)
+                                      unsafeEnqueue s second c
                                       -- putStrLn $ "Biclause propagation from: " ++ show p ++ " to " ++ show second ++ " by " ++ show c
                                       forClause (i + 1) (j + 1)
-                        LiftedF -> do ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
+                        LiftedF -> do setNth bvec j second
+                                      print (falseLit, i, qc, sv, i - j, second)
+                                      ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
                                       -- putStrLn $ "Biclause conflict with: " ++ show p ++ " and " ++ show second ++ " by " ++ show c
                                       set' qHead =<< get' trail
                                       copy (i + 1) (j + 1)
-                                      shrinkBy ws (i - j) >> return c
+                                      shrinkBy ws (i - j) >> return (BiClause second falseLit)
                     _ -> do
                       let !lstack = lits c
                       tmp <- getNth lstack 1
@@ -856,7 +872,7 @@ solve s@Solver{..} assumps = do
                             cancelUntil s 0
                             return False
                     else return True
-  good <- simplifyDB s
+  good <- return True -- simplifyDB s
   x <- if good then foldrM inject True assumps else return False
   if not x
     then return False
@@ -887,6 +903,8 @@ solve s@Solver{..} assumps = do
 {-# INLINABLE unsafeEnqueue #-}
 unsafeEnqueue :: Solver -> Lit -> Clause -> IO ()
 unsafeEnqueue s@Solver{..} p from = do
+  c <- asList from
+  putStrLn $ "Unsafe Enqueue: " ++ show (p, sort c)
   let v = lit2var p
   setNth assigns v $ lit2lbool p
   setNth level v =<< decisionLevel s

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -484,7 +484,7 @@ propagate s@Solver{..} = do
                       let second = if l1 == falseLit then l2 else l1
                       sv <- valueLit s second
                       setNth cvec j c >> setNth bvec j l1
-                      print sv
+                      print (i, second, sv)
                       case sv of
                         LiftedT -> do forClause (i + 1) (j + 1)
                         LBottom -> do unsafeEnqueue s second c

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -484,6 +484,7 @@ propagate s@Solver{..} = do
                       let second = if l1 == falseLit then l2 else l1
                       sv <- valueLit s second
                       setNth cvec j c >> setNth bvec j l1
+                      print sv
                       case sv of
                         LiftedT -> do forClause (i + 1) (j + 1)
                         LBottom -> do unsafeEnqueue s second c

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -295,6 +295,7 @@ analyze s@Solver{..} confl = do
                             Clause{..} -> do
                               r' <- get' rc
                               when (r < r') $ varBumpActivity s v
+                            BiClause{} | r == 1 -> varBumpActivity s v
                             _ -> return ()
                           loopOnLastDL $ i - 1
   loopOnLastDL =<< get' an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -62,10 +62,10 @@ newLearntClause s@Solver{..} ps = do
        l2 <- getNth ps 2
        let c = BiClause l1 l2
        -- inplaceSubsume s clauses c
-       subsumeAll s 1 c
-       subsumeAll s 2 c
-       pushTo learnts c
-       -- pushTo clauses c
+       -- subsumeAll s 1 c
+       -- subsumeAll s 2 c
+       -- pushTo learnts c
+       pushTo clauses c
        pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
        pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
        unsafeEnqueue s l1 c
@@ -957,6 +957,14 @@ subsumeAll s kin (BiClause l1 l2) = do
               then removeWatch s c >> loop (i + 1) j
               else do unless (i == j) $ setNth cvec j c >> setNth bvec j b
                       loop (i + 1) (j + 1)
+          BiClause x y | lit2var x == lit2var l1 -> do
+                           -- print ((x,y), (l1, l2))
+                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                           loop (i + 1) (j + 1)
+          BiClause x y | lit2var x == lit2var l2 -> do
+                           -- print ((x,y), (l2, l1))
+                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                           loop (i + 1) (j + 1)
           _ -> do unless (i == j) $ setNth cvec j c >> setNth bvec j b
                   loop (i + 1) (j + 1)
   n' <- loop start start

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -794,7 +794,7 @@ search s@Solver{..} nOfConflicts = do
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:
-            when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
+            -- when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
             k1 <- get' learnts
             k2 <- nAssigns s
             when (k1 - k2 >= nOfLearnts) $ do   -- This is a cheap check.
@@ -823,6 +823,7 @@ search s@Solver{..} nOfConflicts = do
                        toggleAt ((<= nv) -> False) = return ()
                        toggleAt i = modifyNth phases toggle i >> toggleAt (i + 1)
                    toggleAt 1
+                   void $ simplifyDB s -- our simplifier cannot return @False@ here
                    incrementStat s NumOfRestart 1
                    return LBottom
              _ -> do

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -62,7 +62,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       -- print (l1, l2)
+       print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
        -- unbumpSubsumables learnts c

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -62,10 +62,13 @@ newLearntClause s@Solver{..} ps = do
        l2 <- getNth ps 2
        let c = BiClause l1 l2
        -- inplaceSubsume s clauses c
-       -- subsumeAll s 1 c
-       -- subsumeAll s 2 c
-       -- pushTo learnts c
-       pushTo clauses c
+       -- subsumeAll s clauses c
+       -- unbumpSubsumables learnts c
+       -- unbumpSubsumees (getNthWatcher watches (negateLit l1)) c
+       -- unbumpSubsumees (getNthWatcher watches (negateLit l2)) c
+       -- subsumeAll s learnts c
+       pushTo learnts c
+       -- pushTo clauses c
        pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
        pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
        unsafeEnqueue s l1 c
@@ -928,13 +931,11 @@ inplaceSubsume s clss b@(BiClause l1 l2) = do
   loop 0
 
 -- | purges all clauses which the biclause can subsume
-subsumeAll :: Solver -> Int -> Clause -> IO Bool
-subsumeAll s kin (BiClause l1 l2) = do
-  let clss = if kin == 1 then clauses s else learnts s
-  n <- get' clss
-  let start = if kin == 1 then 0 else div n 2
-  cvec <- getClauseVector clss
-  bvec <- getKeyVector clss
+subsumeAll :: Solver -> ClauseExtManager -> Clause -> IO Bool
+subsumeAll s mgr (BiClause l1 l2) = do
+  n <- get' mgr
+  cvec <- getClauseVector mgr
+  bvec <- getKeyVector mgr
   let loop ((< n) -> False) j = return j
       loop i j = do
         c <- getNth cvec i
@@ -967,7 +968,30 @@ subsumeAll s kin (BiClause l1 l2) = do
                            loop (i + 1) (j + 1)
           _ -> do unless (i == j) $ setNth cvec j c >> setNth bvec j b
                   loop (i + 1) (j + 1)
-  n' <- loop start start
+  n' <- loop 0 0
   if n' < n
-    then shrinkBy clss (n - n') >> reset (watches s) >> return True
+    then shrinkBy mgr (n - n') >> reset (watches s) >> return True
     else return False
+
+-- | _purges_ degrade activity of all clauses which the biclause can subsume
+unbumpSubsumees :: ClauseExtManager -> Clause -> IO ()
+unbumpSubsumees mgr (BiClause l1 l2) = do
+  n <- get' mgr
+  cvec <- getClauseVector mgr
+  let loop ((< n) -> False) = return ()
+      loop i = do
+        c <- getNth cvec i
+        case c of
+          Clause{..} -> do
+            let check :: Bool -> Bool -> Int -> IO Bool
+                check True True _ = return True
+                check _ _ 0 = return False
+                check a b i = do l <- getNth lits i
+                                 if -l == l1 || -1 == l2
+                                   then return False
+                                   else check (l == l1 || a) (l == l2 || b) (i - 1)
+            y <- check False False =<< get' c
+            when y $ modify' activity (* 0.1)
+          _ -> return ()
+        loop (i + 1)
+  loop 0

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -57,7 +57,6 @@ newLearntClause s@Solver{..} ps = do
      1 -> do                    -- a fact
        l <- getNth ps 1
        unsafeEnqueue s l NullClause
-{-
      2 -> do                    -- biclause
        l1 <- getNth ps 1
        l2 <- getNth ps 2
@@ -69,7 +68,6 @@ newLearntClause s@Solver{..} ps = do
        pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
        pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
        unsafeEnqueue s l1 c
--}
      _ -> do
        -- allocate clause:
        c <- makeClauseFromStack clsPool ps --  newClauseFromStack True ps
@@ -111,7 +109,6 @@ newLearntClause s@Solver{..} ps = do
 {-# INLINABLE simplify #-}
 simplify :: Solver -> Clause -> IO Bool
 simplify s (BiClause l1 l2) = do
-  error "oooo"
   v <- valueLit s l1
   if v == LiftedT
     then return True

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -174,9 +174,9 @@ analyze s@Solver{..} confl = do
                       -- glucose heuristics
                       r <- getNth reason v
                       case r of
+                        BiClause{} -> pushTo an'lastDL q
                         Clause{} -> do ra <- get' (rank r)
-                                       rn <- get' r
-                                       when (rn == 2 || 0 < ra) $ pushTo an'lastDL q --
+                                       when (0 < ra) $ pushTo an'lastDL q
                         _        -> return ()
                       -- end of glucose heuristics
                       return (b, pc + 1)
@@ -232,9 +232,9 @@ analyze s@Solver{..} confl = do
                       -- UPDATEVARACTIVITY: glucose heuristics
                       r <- getNth reason v
                       case r of
+                        BiClause{} -> pushTo an'lastDL q
                         Clause{} -> do ra <- get' (rank r)
-                                       rn <- get' r
-                                       when (rn == 2 || 0 < ra) $ pushTo an'lastDL q
+                                       when (0 < ra) $ pushTo an'lastDL q
                         _        -> return ()
                       -- end of glucose heuristics
                       loopOnLiterals (j + 1) b (pc + 1)
@@ -292,9 +292,10 @@ analyze s@Solver{..} confl = do
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
                           rc <- getNth reason v
                           case rc of
+                            BiClause{} -> varBumpActivity s v
                             Clause{..} -> do
                               r' <- get' rc
-                              when (2 < r' && r < r') $ varBumpActivity s v
+                              when (r < r') $ varBumpActivity s v
                             _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -945,7 +945,7 @@ subsumeAll s clss (BiClause l1 l2) = do
         case c :: Clause of
           Clause{..} -> do
             let check :: Lit -> Lit -> Int -> IO Bool
-                check _ 0 0 _ = return True
+                check 0 0 _ = return True
                 check _ _ 0 = return False
                 check a b i = do
                   l <- getNth lits i

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -936,7 +936,7 @@ subsumeAll s clss (BiClause l1 l2) = do
         case c :: Clause of
           Clause{..} -> do
             let check :: Lit -> Lit -> Int -> IO Bool
-                check _ 0 0 _ = return True
+                check 0 0 _ = return True
                 check _ _ 0 = return False
                 check a b i = do
                   l <- getNth lits i

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -18,7 +18,6 @@ module SAT.Mios.Main
 import Control.Monad (unless, void, when)
 import Data.Bits
 import Data.Foldable (foldrM)
-import Data.List
 import SAT.Mios.Types
 import SAT.Mios.Clause
 import SAT.Mios.ClauseManager
@@ -62,7 +61,6 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       -- print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
        -- subsumeAll s learnts c
@@ -170,7 +168,6 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
-                -- putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -178,7 +175,8 @@ analyze s@Solver{..} confl = do
                       r <- getNth reason v
                       case r of
                         Clause{} -> do ra <- get' (rank r)
-                                       when (2 < ra) $ pushTo an'lastDL q
+                                       rn <- get' r
+                                       when (rn == 2 || 0 < ra) $ pushTo an'lastDL q --
                         _        -> return ()
                       -- end of glucose heuristics
                       return (b, pc + 1)
@@ -228,7 +226,6 @@ analyze s@Solver{..} confl = do
           if sn == 0 && 0 < l
             then do
                 varBumpActivity s v
-                -- putStrLn ("bump " ++ show v)
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
@@ -236,7 +233,8 @@ analyze s@Solver{..} confl = do
                       r <- getNth reason v
                       case r of
                         Clause{} -> do ra <- get' (rank r)
-                                       when (2 < ra && 0 /= ra) $ pushTo an'lastDL q
+                                       rn <- get' r
+                                       when (rn == 2 || 0 < ra) $ pushTo an'lastDL q
                         _        -> return ()
                       -- end of glucose heuristics
                       loopOnLiterals (j + 1) b (pc + 1)
@@ -296,7 +294,7 @@ analyze s@Solver{..} confl = do
                           case rc of
                             Clause{..} -> do
                               r' <- get' rc
-                              when (2 < r' && r < r') $ varBumpActivity s v -- >> putStrLn ("bump loopOnLastDL" ++ show v)
+                              when (2 < r' && r < r') $ varBumpActivity s v
                             _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
@@ -478,18 +476,12 @@ propagate s@Solver{..} = do
       let forClause :: Int -> Int -> IO Clause
           forClause i@((< end) -> False) !j = shrinkBy ws (i - j) >> return confl
           forClause !i !j = do
-            qq <- getNth cvec i
-            (qn, qc) <- case qq of
-                         BiClause {} -> do qc <- asList qq; return (2, sort qc)
-                         _ -> return (0, [])
             (blocker :: Lit) <- getNth bvec i        -- Try to avoid inspecting the clause:
-            -- when (qn == 2) $ do putStr $ show qc ++ ":" ++ show (p, blocker) ++ " => "
             bv <- if blocker == 0 then return LiftedF else valueLit s blocker
             if bv == LiftedT
               then do unless (i == j) $ do (c :: Clause) <- getNth cvec i
                                            setNth cvec j c
                                            setNth bvec j blocker
-                      -- when (qn == 2) $ print (falseLit, i, qc, LiftedT, i - j, blocker)
                       forClause (i + 1) (j + 1)
               else do                               -- Make sure the false literal is data[1]:
                   (c :: Clause) <- getNth cvec i
@@ -499,17 +491,12 @@ propagate s@Solver{..} = do
                       sv <- valueLit s second
                       setNth cvec j c >> setNth bvec j l1
                       case sv of
-                        LiftedT -> do -- print (falseLit, i, qc, sv, i - j, l1)
-                                      forClause (i + 1) (j + 1)
+                        LiftedT -> do forClause (i + 1) (j + 1)
                         LBottom -> do setNth bvec j second
-                                      -- print (falseLit, i, qc, sv, i - j, second)
                                       unsafeEnqueue s second c
-                                      -- putStrLn $ "Biclause propagation from: " ++ show p ++ " to " ++ show second ++ " by " ++ show c
                                       forClause (i + 1) (j + 1)
                         LiftedF -> do setNth bvec j second
-                                      -- print (falseLit, i, qc, sv, i - j, second)
                                       ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
-                                      -- putStrLn $ "Biclause conflict with: " ++ show p ++ " and " ++ show second ++ " by " ++ show c
                                       set' qHead =<< get' trail
                                       copy (i + 1) (j + 1)
                                       shrinkBy ws (i - j) >> return (BiClause second falseLit)
@@ -789,7 +776,7 @@ search s@Solver{..} nOfConflicts = do
                     set' learntSAdj t'
                     set' learntSCnt $ floor t'
                     modify' maxLearnts (* 1.1)
--- {-
+{-
                     -- verbose
                     let w8 :: Int -> String -> String
                         w8 (show -> i) p = take (8 - length i) "          " ++ i ++ p
@@ -801,11 +788,11 @@ search s@Solver{..} nOfConflicts = do
                     vn <- (nVars -) <$> if va == 0 then get' trail else getNth trailLim 1
                     vp <- getStat s NumOfPropagation
                     putStrLn $ w8 vb " | " ++ w8 vn " " ++ w8 gc " | " ++ w8 vm " " ++ w8 vc " | " ++ w8 vp ""
--- -}
+-}
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:
-            -- when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
+            when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
             k1 <- get' learnts
             k2 <- nAssigns s
             when (k1 - k2 >= nOfLearnts) $ do   -- This is a cheap check.
@@ -872,7 +859,7 @@ solve s@Solver{..} assumps = do
                             cancelUntil s 0
                             return False
                     else return True
-  good <- return True -- simplifyDB s
+  good <- simplifyDB s
   x <- if good then foldrM inject True assumps else return False
   if not x
     then return False
@@ -903,8 +890,6 @@ solve s@Solver{..} assumps = do
 {-# INLINABLE unsafeEnqueue #-}
 unsafeEnqueue :: Solver -> Lit -> Clause -> IO ()
 unsafeEnqueue s@Solver{..} p from = do
-  c <- asList from
-  -- putStrLn $ "Unsafe Enqueue: " ++ show (p, sort c)
   let v = lit2var p
   setNth assigns v $ lit2lbool p
   setNth level v =<< decisionLevel s

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -174,9 +174,9 @@ analyze s@Solver{..} confl = do
                       -- glucose heuristics
                       r <- getNth reason v
                       case r of
+                        BiClause{} -> pushTo an'lastDL q
                         Clause{} -> do ra <- get' (rank r)
-                                       rn <- get' r
-                                       when (rn == 2 || 0 < ra) $ pushTo an'lastDL q --
+                                       when (0 < ra) $ pushTo an'lastDL q
                         _        -> return ()
                       -- end of glucose heuristics
                       return (b, pc + 1)
@@ -232,9 +232,9 @@ analyze s@Solver{..} confl = do
                       -- glucose heuristics
                       r <- getNth reason v
                       case r of
+                        BiClause{} -> pushTo an'lastDL q
                         Clause{} -> do ra <- get' (rank r)
-                                       rn <- get' r
-                                       when (rn == 2 || 0 < ra) $ pushTo an'lastDL q
+                                       when (0 < ra) $ pushTo an'lastDL q
                         _        -> return ()
                       -- end of glucose heuristics
                       loopOnLiterals (j + 1) b (pc + 1)
@@ -292,9 +292,10 @@ analyze s@Solver{..} confl = do
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
                           rc <- getNth reason v
                           case rc of
+                            BiClause{} -> varBumpActivity s v
                             Clause{..} -> do
                               r' <- get' rc
-                              when (2 < r' && r < r') $ varBumpActivity s v
+                              when (r < r') $ varBumpActivity s v
                             _ -> return ()
                           loopOnLastDL $ i + 1
   loopOnLastDL 1

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -147,7 +147,6 @@ analyze s@Solver{..} confl = do
     loopOnClauseChain :: Clause -> Lit -> Int -> Int -> Int -> IO Int
     loopOnClauseChain NullClause lit _ _ _ = error $ "strange analyze loop: " ++ show lit
     loopOnClauseChain c@(BiClause l1 l2) p ti bl pathC = do -- p : literal, ti = trail index, bl = backtrack level
-      -- putStrLn $ "analyze on biclause: " ++ show (c, confl, confl == c)
       let
         loopOnLiterals :: Lit -> Int -> Int -> IO (Int, Int)
         loopOnLiterals q b pc = do
@@ -163,31 +162,21 @@ analyze s@Solver{..} confl = do
                       -- glucose heuristics
                       r <- getNth reason v
                       case r of
-                        NullClause   -> return () -- setNth an'seen v 0
-                        BiClause _ _ -> return ()
-                        _            -> do
-                          ra <- get' (rank r)
-                          when (0 /= ra) $ pushTo an'lastDL q
+                        Clause{} -> do ra <- get' (rank r)
+                                       when (0 /= ra) $ pushTo an'lastDL q
+                        _        -> return ()
                       -- end of glucose heuristics
-                      -- loopOnLiterals (j + 1) b (pc + 1)
                       return (b, pc + 1)
-                  else pushTo litsLearnt q >> return (max b l, pc) -- loopOnLiterals (j + 1) (max b l) pc
-            else return (b, pc) -- loopOnLiterals (j + 1) b pc
+                  else pushTo litsLearnt q >> return (max b l, pc)
+            else return (b, pc)
       -- Two posibility:
       -- * this biclause @b@ is used on the depdendency tree; target should be the literal which reason is NOT @b@.
       -- * this biclause @b@ is the conflicting clause; @b@ is not stored in reason; target is the literal which is assigned.
-      -- print (r1 == c, r2 == c, r1 == NullClause, r2 == NullClause) 
       (b', pathC') <- if p == LBottom
                       then do (b1, pathC1) <- loopOnLiterals l1 bl pathC
                               loopOnLiterals l2 b1 pathC1
                       else do r1 <- getNth reason (lit2var l1)
                               loopOnLiterals (if r1 == c then l2 else l1) bl pathC
-{-
-      let target = if r1 /= c && r2 /= c
-                   then if v1 /= LBottom then 1 else 2 -- if r1 == NullClause then 2 else 1
-                   else if r1 == c then 2 else 1
-      (b', pathC') <- loopOnLiterals target bl pathC
--}
       let
         -- select next clause to look at
         nextPickedUpLit :: Int -> IO Int
@@ -230,11 +219,9 @@ analyze s@Solver{..} confl = do
                       -- glucose heuristics
                       r <- getNth reason v
                       case r of
-                        NullClause   -> return ()
-                        BiClause _ _ -> return ()
-                        _            -> do
-                          ra <- get' (rank r)
-                          when (0 /= ra) $ pushTo an'lastDL q
+                        Clause{} -> do ra <- get' (rank r)
+                                       when (0 /= ra) $ pushTo an'lastDL q
+                        _        -> return ()
                       -- end of glucose heuristics
                       loopOnLiterals (j + 1) b (pc + 1)
                   else pushTo litsLearnt q >> loopOnLiterals (j + 1) (max b l) pc
@@ -304,7 +291,7 @@ analyze s@Solver{..} confl = do
   cleaner 1
   return levelToReturn
 
--- | #M114
+-- | #M114 @litRedundant@
 -- Check if 'p' can be removed, 'abstract_levels' is used to abort early if the algorithm is
 -- visiting literals at levels that cannot be removed later.
 --
@@ -314,7 +301,7 @@ analyze s@Solver{..} confl = do
 --   This is used only in this function and @analyze@.
 --
 analyzeRemovable :: Solver -> Lit -> Int -> IO Bool
-analyzeRemovable Solver{..} p minLevel = do
+analyzeRemovable s@Solver{..} p minLevel = do
   -- assert (reason[var(p)] != NullClause);
   reset an'stack      -- analyze_stack.clear()
   pushTo an'stack p   -- analyze_stack.push(p);
@@ -330,7 +317,28 @@ analyzeRemovable Solver{..} p minLevel = do
             popFrom an'stack             -- analyze_stack.pop();
             c <- getNth reason (lit2var sl) -- getRoot sl
             case c of
-              BiClause l1 l2 -> do return False
+              BiClause l1 l2 -> do
+                a1 <- valueLit s l1
+                let p' = if a1 == LiftedF then l1 else l2 -- See: glucose/core/Solver.cc l.699
+                    v' = lit2var p'
+                l' <- getNth level v'
+                c1 <- (1 /=) <$> getNth an'seen v'
+                if c1 && (0 /= l')
+                  then do
+                      c3 <- (NullClause /=) <$> getNth reason v'
+                      if c3 && testBit minLevel (l' .&. 31)
+                        then do setNth an'seen v' 1   -- analyze_seen[var(p)] = 1;
+                                pushTo an'stack p'    -- analyze_stack.push(p);
+                                pushTo an'toClear p'  -- analyze_toclear.push(p);
+                                loopOnStack
+                        else do top' <- get' an'toClear
+                                let clearAll :: Int -> IO ()
+                                    clearAll ((<= top') -> False) = return ()
+                                    clearAll j = do x <- getNth an'toClear j; setNth an'seen (lit2var x) 0; clearAll (j + 1)
+                                clearAll $ top + 1
+                                shrinkBy an'toClear $ top' - top
+                                return False
+                  else loopOnStack
               _ -> do
                 nl <- get' c
                 let

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -147,7 +147,7 @@ analyze s@Solver{..} confl = do
     loopOnClauseChain :: Clause -> Lit -> Int -> Int -> Int -> IO Int
     loopOnClauseChain NullClause lit _ _ _ = error $ "strange analyze loop: " ++ show lit
     loopOnClauseChain c@(BiClause l1 l2) p ti bl pathC = do -- p : literal, ti = trail index, bl = backtrack level
-      putStrLn $ "analyze on biclause: " ++ show (c, confl, confl == c)
+      -- putStrLn $ "analyze on biclause: " ++ show (c, confl, confl == c)
       let
         loopOnLiterals :: Lit -> Int -> Int -> IO (Int, Int)
         loopOnLiterals q b pc = do
@@ -158,7 +158,6 @@ analyze s@Solver{..} confl = do
             then do
                 varBumpActivity s v
                 setNth an'seen v 1
-                print v
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
                       -- glucose heuristics
@@ -174,11 +173,6 @@ analyze s@Solver{..} confl = do
                       return (b, pc + 1)
                   else pushTo litsLearnt q >> return (max b l, pc) -- loopOnLiterals (j + 1) (max b l) pc
             else return (b, pc) -- loopOnLiterals (j + 1) b pc
-      r1 <- getNth reason (lit2var l1)
---      r2 <- getNth reason (lit2var l2)
---      v1 <- valueLit s l1
---      v2 <- valueLit s l2
-      when ((c == confl) /= (p == LBottom)) $ error "!!!@@@@@@@@@@@@@@@22"
       -- Two posibility:
       -- * this biclause @b@ is used on the depdendency tree; target should be the literal which reason is NOT @b@.
       -- * this biclause @b@ is the conflicting clause; @b@ is not stored in reason; target is the literal which is assigned.
@@ -186,7 +180,8 @@ analyze s@Solver{..} confl = do
       (b', pathC') <- if p == LBottom
                       then do (b1, pathC1) <- loopOnLiterals l1 bl pathC
                               loopOnLiterals l2 b1 pathC1
-                      else loopOnLiterals (if r1 == c then l2 else l1) bl pathC
+                      else do r1 <- getNth reason (lit2var l1)
+                              loopOnLiterals (if r1 == c then l2 else l1) bl pathC
 {-
       let target = if r1 /= c && r2 /= c
                    then if v1 /= LBottom then 1 else 2 -- if r1 == NullClause then 2 else 1
@@ -230,7 +225,6 @@ analyze s@Solver{..} confl = do
             then do
                 varBumpActivity s v
                 setNth an'seen v 1
-                when (sc == 2) (print v)
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
                       -- glucose heuristics
@@ -261,7 +255,6 @@ analyze s@Solver{..} confl = do
         else setNth litsLearnt 1 (negateLit nextP) >> return b'
   ti <- subtract 1 <$> get' trail
   levelToReturn <- loopOnClauseChain confl bottomLit ti 0 0
-  putStrLn "done"
   -- Simplify phase (implemented only @expensive_ccmin@ path)
   n <- get' litsLearnt
   reset an'stack           -- analyze_stack.clear();
@@ -468,20 +461,16 @@ propagate s@Solver{..} = do
                   (c :: Clause) <- getNth cvec i
                   case c of
                     BiClause l1 l2 -> do
-                      let first = if l1 == falseLit then l1 else l2
                       let second = if l1 == falseLit then l2 else l1
-                      ch <- valueLit s first
-                      bv' <- valueLit s blocker
                       sv <- valueLit s second
-                      when (ch /= LiftedF) $ error $ "strange literal" ++ show ((blocker, bv'), l1, l2, (ch, sv))
                       setNth cvec j c >> setNth bvec j l1
                       case sv of
                         LiftedT -> do forClause (i + 1) (j + 1)
                         LBottom -> do unsafeEnqueue s second c
-                                      putStrLn $ "Biclause propagation from: " ++ show p ++ " to " ++ show second ++ " by " ++ show c
+                                      -- putStrLn $ "Biclause propagation from: " ++ show p ++ " to " ++ show second ++ " by " ++ show c
                                       forClause (i + 1) (j + 1)
                         LiftedF -> do ((== 0) <$> decisionLevel s) >>= (`when` set' ok False)
-                                      putStrLn $ "Biclause conflict with: " ++ show p ++ " and " ++ show second ++ " by " ++ show c
+                                      -- putStrLn $ "Biclause conflict with: " ++ show p ++ " and " ++ show second ++ " by " ++ show c
                                       set' qHead =<< get' trail
                                       copy (i + 1) (j + 1)
                                       shrinkBy ws (i - j) >> return c

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -693,7 +693,8 @@ sortClauses s cm limit = do
 --   thing done here is the removal of satisfied clauses, but more things can be put here.
 --
 simplifyDB :: Solver -> IO Bool
-simplifyDB s@Solver{..} = do
+simplifyDB s@Solver{..} = do return True
+{-
   good <- get' ok
   if good
     then do
@@ -727,6 +728,7 @@ simplifyDB s@Solver{..} = do
             reset watches
             return ret
     else return False
+-}
 
 -- | #M22
 --

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -693,7 +693,8 @@ sortClauses s cm limit = do
 --   thing done here is the removal of satisfied clauses, but more things can be put here.
 --
 simplifyDB :: Solver -> IO Bool
-simplifyDB s@Solver{..} = do
+simplifyDB s@Solver{..} = do return True
+{-
   good <- get' ok
   if good
     then do
@@ -726,6 +727,7 @@ simplifyDB s@Solver{..} = do
             reset watches
             return True
     else return False
+-}
 
 -- | #M22
 --

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -61,7 +61,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       print (l1, l2)
+       -- print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
        -- unbumpSubsumables learnts c
@@ -770,7 +770,7 @@ search s@Solver{..} nOfConflicts = do
                     set' learntSAdj t'
                     set' learntSCnt $ floor t'
                     modify' maxLearnts (* 1.1)
-{-
+-- {-
                     -- verbose
                     let w8 :: Int -> String -> String
                         w8 (show -> i) p = take (8 - length i) "          " ++ i ++ p
@@ -782,7 +782,7 @@ search s@Solver{..} nOfConflicts = do
                     vn <- (nVars -) <$> if va == 0 then get' trail else getNth trailLim 1
                     vp <- getStat s NumOfPropagation
                     putStrLn $ w8 vb " | " ++ w8 vn " " ++ w8 gc " | " ++ w8 vm " " ++ w8 vc " | " ++ w8 vp ""
--}
+-- -}
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -61,12 +61,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       -- inplaceSubsume s clauses c
-       -- subsumeAll s clauses c
-       -- subsumeAll s learnts c
-       -- unbumpSubsumables learnts c
-       -- unbumpSubsumees (getNthWatcher watches (negateLit l1)) c
-       -- unbumpSubsumees (getNthWatcher watches (negateLit l2)) c
+       subsumeAll s clauses c
        -- subsumeAll s learnts c
        pushTo learnts c
        -- pushTo clauses c
@@ -697,35 +692,40 @@ simplifyDB s@Solver{..} = do return True
 {-
   good <- get' ok
   if good
-    then do
-      p <- propagate s
-      if p /= NullClause
-        then set' ok False >> return False
-        else do
-            -- Remove satisfied clauses and their watcher lists:
-            let
-              for :: ClauseExtManager -> IO ()
-              for mgr = do
-                vec' <- getClauseVector mgr
-                n' <- get' mgr
-                let
-                  loopOnVector :: Int -> Int -> IO ()
-                  loopOnVector ((< n') -> False) j = shrinkBy mgr (n' - j)
-                  loopOnVector i j = do
-                        c <- getNth vec' i
-                        case c of
-                          BiClause{} -> unless (i == j) (setNth vec' j c) >> loopOnVector (i + 1) (j + 1)
-                          _ -> do
-                            l <- locked s c
-                            r <- if l then return False else simplify s c
-                            if r
-                              then removeWatch s c >> loopOnVector (i + 1) j
-                              else unless (i == j) (setNth vec' j c) >> loopOnVector (i + 1) (j + 1)
-                loopOnVector 0 0
-            for clauses
-            for learnts
-            reset watches
-            return True
+    then do p <- propagate s
+            if p /= NullClause
+              then set' ok False >> return False
+              else do let check :: Int -> IO () -- canonize reasons at level = 0
+                          check ((< nVars) -> False) = return ()
+                          check i = do asg <- getNth assigns i
+                                       l <- getNth level i
+                                       when (asg /= LBottom && l == 0) $ do
+                                         r <- getNth reason i
+                                         when (r /= NullClause) $ setNth reason i NullClause
+                                       check $ i + 1
+                      check 0
+                      let for :: ClauseExtManager -> IO ()
+                          for mgr = do
+                            vec' <- getClauseVector mgr
+                            n' <- get' mgr
+                            let loopOnVector :: Int -> Int -> IO ()
+                                loopOnVector ((< n') -> False) j = shrinkBy mgr (n' - j)
+                                loopOnVector i j = do
+                                  c <- getNth vec' i
+                                  case c of
+                                    BiClause{} -> unless (i == j) (setNth vec' j c) >> loopOnVector (i + 1) (j + 1)
+                                    _ -> do
+                                      l <- locked s c
+                                      r <- if l then return False else simplify s c
+                                      if r
+                                        then removeWatch s c >> loopOnVector (i + 1) j
+                                        else unless (i == j) (setNth vec' j c) >> loopOnVector (i + 1) (j + 1)
+                            loopOnVector 0 0
+                      -- Remove satisfied clauses:
+                      for clauses
+                      for learnts
+                      reset watches
+                      return True
     else return False
 -}
 
@@ -794,7 +794,7 @@ search s@Solver{..} nOfConflicts = do
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:
-            -- when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
+            when (d == 0) . void $ simplifyDB s -- our simplifier cannot return @False@ here
             k1 <- get' learnts
             k2 <- nAssigns s
             when (k1 - k2 >= nOfLearnts) $ do   -- This is a cheap check.
@@ -823,7 +823,6 @@ search s@Solver{..} nOfConflicts = do
                        toggleAt ((<= nv) -> False) = return ()
                        toggleAt i = modifyNth phases toggle i >> toggleAt (i + 1)
                    toggleAt 1
-                   void $ simplifyDB s -- our simplifier cannot return @False@ here
                    incrementStat s NumOfRestart 1
                    return LBottom
              _ -> do
@@ -919,6 +918,48 @@ luby y x_ = loop 1 0
       | sz - 1 == x = y ** fromIntegral sq
       | otherwise   = let s = div (sz - 1) 2 in loop2 (mod x s) s (sq - 1)
 
+-- | purges all clauses which the biclause can subsume
+subsumeAll :: Solver -> ClauseExtManager -> Clause -> IO Bool
+subsumeAll s mgr (BiClause l1 l2) = do
+  n <- get' mgr
+  cvec <- getClauseVector mgr
+  bvec <- getKeyVector mgr
+  let loop ((< n) -> False) j = return j
+      loop i j = do
+        c <- getNth cvec i
+        b <- getNth bvec i
+        case c :: Clause of
+          Clause{..} -> do
+            let check :: Bool -> Bool -> Int -> IO Bool
+                check True True _ = return True
+                check _ _ 0 = return False
+                check a b i = do l <- getNth lits i
+                                 if -l == l1 || -1 == l2
+                                   then return False
+                                   else check (l == l1 || a) (l == l2 || b) (i - 1)
+            y <- check False False =<< get' c
+            -- locked s c ; interestingly, a clause that can be subsumed is never used as reason.
+            -- The literal which level is highest in a learnt has been unassigned by cancelUntil.
+            if y                -- subsumed
+              then removeWatch s c >> loop (i + 1) j
+              else do unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                      loop (i + 1) (j + 1)
+          BiClause x y | lit2var x == lit2var l1 -> do
+                           -- print ((x,y), (l1, l2))
+                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                           loop (i + 1) (j + 1)
+          BiClause x y | lit2var x == lit2var l2 -> do
+                           -- print ((x,y), (l2, l1))
+                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                           loop (i + 1) (j + 1)
+          _ -> do unless (i == j) $ setNth cvec j c >> setNth bvec j b
+                  loop (i + 1) (j + 1)
+  n' <- loop 0 0
+  if n' < n
+    then shrinkBy mgr (n - n') >> reset (watches s) >> return True
+    else return False
+
+{-
 inplaceSubsume :: Solver -> ClauseExtManager -> Clause -> IO Bool
 inplaceSubsume s clss b@(BiClause l1 l2) = do
   n <- get' clss
@@ -941,49 +982,6 @@ inplaceSubsume s clss b@(BiClause l1 l2) = do
           _ -> loop (i + 1)
   loop 0
 
--- | purges all clauses which the biclause can subsume
-subsumeAll :: Solver -> ClauseExtManager -> Clause -> IO Bool
-subsumeAll s mgr (BiClause l1 l2) = do
-  n <- get' mgr
-  cvec <- getClauseVector mgr
-  bvec <- getKeyVector mgr
-  let loop ((< n) -> False) j = return j
-      loop i j = do
-        c <- getNth cvec i
-        b <- getNth bvec i
-        case c :: Clause of
-          Clause{..} -> do
-            let check :: Bool -> Bool -> Int -> IO Bool
-                check True True _ = return True
-                check _ _ 0 = return False
-                check a b i = do l <- getNth lits i
-                                 if -l == l1 || -1 == l2
-                                   then return False
-                                   else check (l == l1 || a) (l == l2 || b) (i - 1)
-            y <- check False False =<< get' c
-            -- l <- locked s c
-            -- when (l && y) $ error "AAAA"
-            -- locked s c ; interestingly, a clause that can be subsumed is never used as reason.
-            -- The literal which level is highest in a learnt has been unassigned by cancelUntil.
-            if y                -- subsumed
-              then removeWatch s c >> loop (i + 1) j
-              else do unless (i == j) $ setNth cvec j c >> setNth bvec j b
-                      loop (i + 1) (j + 1)
-          BiClause x y | lit2var x == lit2var l1 -> do
-                           -- print ((x,y), (l1, l2))
-                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
-                           loop (i + 1) (j + 1)
-          BiClause x y | lit2var x == lit2var l2 -> do
-                           -- print ((x,y), (l2, l1))
-                           unless (i == j) $ setNth cvec j c >> setNth bvec j b
-                           loop (i + 1) (j + 1)
-          _ -> do unless (i == j) $ setNth cvec j c >> setNth bvec j b
-                  loop (i + 1) (j + 1)
-  n' <- loop 0 0
-  if n' < n
-    then shrinkBy mgr (n - n') >> reset (watches s) >> return True
-    else return False
-
 -- | _purges_ degrade activity of all clauses which the biclause can subsume
 unbumpSubsumees :: ClauseExtManager -> Clause -> IO ()
 unbumpSubsumees mgr (BiClause l1 l2) = do
@@ -1002,7 +1000,8 @@ unbumpSubsumees mgr (BiClause l1 l2) = do
                                    then return False
                                    else check (l == l1 || a) (l == l2 || b) (i - 1)
             y <- check False False =<< get' c
-            when y $ modify' activity (* 0.1)
+            when y $ set' activity 0 -- modify' activity (* 0.1)
           _ -> return ()
         loop (i + 1)
   loop 0
+-}

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -18,6 +18,7 @@ module SAT.Mios.Main
 import Control.Monad (unless, void, when)
 import Data.Bits
 import Data.Foldable (foldrM)
+import Data.List
 import SAT.Mios.Types
 import SAT.Mios.Clause
 import SAT.Mios.ClauseManager
@@ -484,7 +485,8 @@ propagate s@Solver{..} = do
                       let second = if l1 == falseLit then l2 else l1
                       sv <- valueLit s second
                       setNth cvec j c >> setNth bvec j l1
-                      print (i, second, sv)
+                      x <- asList c
+                      print (i, sort x, sv)
                       case sv of
                         LiftedT -> do forClause (i + 1) (j + 1)
                         LBottom -> do unsafeEnqueue s second c

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -61,7 +61,7 @@ newLearntClause s@Solver{..} ps = do
        l1 <- getNth ps 1
        l2 <- getNth ps 2
        let c = BiClause l1 l2
-       print (l1, l2)
+       -- print (l1, l2)
        -- inplaceSubsume s clauses c
        -- subsumeAll s clauses c
        -- unbumpSubsumables learnts c
@@ -769,7 +769,7 @@ search s@Solver{..} nOfConflicts = do
                     set' learntSAdj t'
                     set' learntSCnt $ floor t'
                     modify' maxLearnts (* 1.1)
-{-
+-- {-
                     -- verbose
                     let w8 :: Int -> String -> String
                         w8 (show -> i) p = take (8 - length i) "          " ++ i ++ p
@@ -781,7 +781,7 @@ search s@Solver{..} nOfConflicts = do
                     vn <- (nVars -) <$> if va == 0 then get' trail else getNth trailLim 1
                     vp <- getStat s NumOfPropagation
                     putStrLn $ w8 vb " | " ++ w8 vn " " ++ w8 gc " | " ++ w8 vm " " ++ w8 vc " | " ++ w8 vp ""
--}
+-- -}
                   loop $ conflictC + 1
         else do                 -- NO CONFLICT
             -- Simplify the set of problem clauses:

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -297,6 +297,7 @@ clauseNew s@Solver{..} ps isLearnt = do
    1 -> do
      l <- getNth ps 1
      Left <$> enqueue s l NullClause
+{-
    2 -> do                    -- biclause
      l1 <- getNth ps 1
      l2 <- getNth ps 2
@@ -304,6 +305,7 @@ clauseNew s@Solver{..} ps isLearnt = do
      pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
      pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
      return (Right c)
+-}
    _ -> do
     -- allocate clause:
      c <- newClauseFromStack isLearnt ps
@@ -332,8 +334,8 @@ clauseNew s@Solver{..} ps isLearnt = do
      -- Add clause to watcher lists:
      l1 <- getNth lstack 1
      l2 <- getNth lstack 2
-     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
-     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
+     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c 0
+     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c 0
      return (Right c)
 
 -- | __Fig. 9 (p.14)__

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -297,15 +297,13 @@ clauseNew s@Solver{..} ps isLearnt = do
    1 -> do
      l <- getNth ps 1
      Left <$> enqueue s l NullClause
-{-
    2 -> do                    -- biclause
      l1 <- getNth ps 1
      l2 <- getNth ps 2
      let c = BiClause l1 l2
-     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
-     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
+     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c 0
+     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c 0
      return (Right c)
--}
    _ -> do
     -- allocate clause:
      c <- newClauseFromStack isLearnt ps

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -187,7 +187,11 @@ valueLit (assigns -> a) p = (\x -> if positiveLit p then x else negate x) <$> ge
 -- returns @True@ if the clause is locked (used as a reason). __Learnt clauses only__
 {-# INLINE locked #-}
 locked :: Solver -> Clause -> IO Bool
-locked s c@(BiClause a _) = (c ==) <$> getNth (reason s) (lit2var a)
+locked s c@(BiClause a b) = do
+  p1 <- (c ==) <$> getNth (reason s) (lit2var a)
+  if p1
+    then return True
+    else (c ==) <$> getNth (reason s) (lit2var b)
 locked s c = (c ==) <$> (getNth (reason s) . lit2var =<< getNth (lits c) 1)
 
 -------------------------------------------------------------------------------- Statistics

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -326,10 +326,10 @@ clauseNew s@Solver{..} ps isLearnt = do
        -- Bumping:
        claBumpActivity s c -- newly learnt clauses should be considered active
      -- Add clause to watcher lists:
-     l1 <- negateLit <$> getNth lstack 1
-     pushClauseWithKey (getNthWatcher watches l1) c 0
-     l2 <- negateLit <$> getNth lstack 2
-     pushClauseWithKey (getNthWatcher watches l2) c 0
+     l1 <- getNth lstack 1
+     l2 <- getNth lstack 2
+     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
+     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
      return (Right c)
 
 -- | __Fig. 9 (p.14)__

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -187,6 +187,7 @@ valueLit (assigns -> a) p = (\x -> if positiveLit p then x else negate x) <$> ge
 -- returns @True@ if the clause is locked (used as a reason). __Learnt clauses only__
 {-# INLINE locked #-}
 locked :: Solver -> Clause -> IO Bool
+locked s c@(BiClause a _) = (c ==) <$> getNth (reason s) (lit2var a)
 locked s c = (c ==) <$> (getNth (reason s) . lit2var =<< getNth (lits c) 1)
 
 -------------------------------------------------------------------------------- Statistics

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -293,6 +293,13 @@ clauseNew s@Solver{..} ps isLearnt = do
    1 -> do
      l <- getNth ps 1
      Left <$> enqueue s l NullClause
+   2 -> do                    -- biclause
+     l1 <- getNth ps 1
+     l2 <- getNth ps 2
+     let c = BiClause l1 l2
+     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2
+     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c l1
+     return (Right c)
    _ -> do
     -- allocate clause:
      c <- newClauseFromStack isLearnt ps

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -470,6 +470,7 @@ claActivityThreshold = 1e20
 -- | __Fig. 14 (p.19)__
 {-# INLINE claBumpActivity #-}
 claBumpActivity :: Solver -> Clause -> IO ()
+claBumpActivity s@Solver{..} (BiClause _ _) = return ()
 claBumpActivity s@Solver{..} Clause{..} = do
   a <- (+) <$> get' activity <*> get' claInc
   set' activity a
@@ -491,7 +492,9 @@ claRescaleActivity Solver{..} = do
     loopOnVector ((< n) -> False) = return ()
     loopOnVector i = do
       c <- getNth vec i
-      modify' (activity c) (/ claActivityThreshold)
+      case c of
+        Clause{..} -> do modify' activity (/ claActivityThreshold)
+        _ -> return ()
       loopOnVector $ i + 1
   loopOnVector 0
   modify' claInc (/ claActivityThreshold)

--- a/src/SAT/Mios/Util/BoolExp.hs
+++ b/src/SAT/Mios/Util/BoolExp.hs
@@ -67,7 +67,10 @@ numberOfVariables (Cnf (a, b) _) = a + b - tseitinBase
 numberOfClauses :: BoolForm -> Int
 numberOfClauses (Cnf _ l) = length l
 
+boolFormTrue :: BoolForm
 boolFormTrue = Cnf (-1, 1) []
+
+boolFormFalse :: BoolForm
 boolFormFalse = Cnf (-1, -1) []
 
 instance BoolComponent Bool where
@@ -186,6 +189,7 @@ disjunctionOf [] = boolFormFalse
 disjunctionOf (x:l) = foldl' (-|-) x l
 
 -- | an alias of 'disjunctionOf'
+(-|||-) :: [BoolForm] -> BoolForm
 (-|||-) = disjunctionOf
 
 -- | merge [BoolForm] by '(-&-)'
@@ -194,6 +198,7 @@ conjunctionOf [] = boolFormTrue
 conjunctionOf (x:l) = foldl' (-&-) x l
 
 -- | an alias of 'conjunctionOf'
+(-&&&-) :: [BoolForm] -> BoolForm
 (-&&&-) = conjunctionOf
 
 -- | converts a BoolForm to "[[Int]]"

--- a/src/SAT/Mios/Util/DIMACS/MinisatReader.hs
+++ b/src/SAT/Mios/Util/DIMACS/MinisatReader.hs
@@ -15,11 +15,13 @@ import Text.ParserCombinators.ReadP
 -- parser
 -- |parse a non-signed integer
 {-# INLINE pint #-}
+pint :: ReadP Int
 pint = do
   n <- munch isDigit
   return (read n :: Int)
 
 {-# INLINE mint #-}
+mint :: ReadP Int
 mint = do
   char '-'
   n <- munch isDigit
@@ -27,15 +29,17 @@ mint = do
 
 -- |parse a (signed) integer
 {-# INLINE int #-}
+int :: ReadP Int
 int = mint <++ pint
 
 -- |return integer list that terminates at zero
 {-# INLINE seqNums #-}
+seqNums :: ReadP [Int]
 seqNums = do
   skipSpaces
   x <- int
   skipSpaces
-  if (x == 0) then return []  else (x :) <$> seqNums
+  if x == 0 then return []  else (x :) <$> seqNums
 
 -- |top level interface for parsing CNF
 {-# INLINE parseMinisatOutput #-}

--- a/src/SAT/Mios/Util/DIMACS/Reader.hs
+++ b/src/SAT/Mios/Util/DIMACS/Reader.hs
@@ -14,24 +14,30 @@ import Text.ParserCombinators.ReadP
 
 -- parser
 {-# INLINE newline #-}
+newline :: ReadP Char
 newline = char '\n'
 
 {-# INLINE digit #-}
+digit :: ReadP Char
 digit = satisfy isDigit
 
 {-# INLINE spaces #-}
+spaces :: ReadP String
 spaces = munch (`elem` " \t")
 
 {-# INLINE noneOf #-}
+noneOf :: Foldable t => t Char -> ReadP Char
 noneOf s = satisfy (`notElem` s)
 
 -- |parse a non-signed integer
 {-# INLINE pint #-}
+pint :: ReadP Int
 pint = do
   n <- munch isDigit
   return (read n :: Int)
 
 {-# INLINE mint #-}
+mint :: ReadP Int
 mint = do
   char '-'
   n <- munch isDigit
@@ -39,10 +45,12 @@ mint = do
 
 -- |parse a (signed) integer
 {-# INLINE int #-}
+int :: ReadP Int
 int = mint <++ pint
 
 -- |Parse something like: p FORMAT VARIABLES CLAUSES
 {-# INLINE problemLine #-}
+problemLine :: ReadP (Int, Int)
 problemLine = do
   char 'p'
   skipSpaces
@@ -57,6 +65,7 @@ problemLine = do
 
 -- |Parse something like: c This in an example of a comment line.
 {-# INLINE commentLines #-}
+commentLines :: ReadP ()
 commentLines = do
   l <- look
   if (head l)  == 'c'
@@ -66,6 +75,7 @@ commentLines = do
       commentLines
     else return ()
 
+_commentLines :: ReadP ()
 _commentLines = do
   char 'c'
   munch ('\n' /=)
@@ -75,12 +85,14 @@ _commentLines = do
 
 -- |Parse the preamble part
 {-# INLINE preambleCNF #-}
+preambleCNF :: ReadP (Int, Int)
 preambleCNF = do
   commentLines
   problemLine
 
 -- |return integer list that terminates at zero
 {-# INLINE seqNums #-}
+seqNums :: ReadP [Int]
 seqNums = do
   skipSpaces
   x <- int
@@ -101,6 +113,7 @@ parseCNF = do
   return (a, b)
 
 -- |driver:: String -> Either ParseError Int
+driver :: String -> [([[Int]], String)]
 driver input = readP_to_S (parseClauses 1) input
 
 -- |read a CNF file and return:


### PR DESCRIPTION
## changelog

- `simplifyDB` is called only after restart. Since this means decision level is zero, `locked` is removed from it. Note: In some problems, the number of propagations increases *by calling `simplifyDB`*. Is it possible!? 😲 

## objective

- Binary clause, or `biclause`, has a specific representation.
- biclause should be handled as a kind of **problem clause**.
- learning a binary clause should be a trigger to simplify or subsumpiton.

## related branch

- investigate the probability of biclause
- comparison to the previous code: #51 

This is a week project. 👨‍⚕️ 
cf #19, #28