### PR TITLE
fix crashes by SC17main/mp1-21.*.cnf

### DIFF
--- a/mios.cabal
+++ b/mios.cabal
@@ -89,7 +89,7 @@ library
   else
     ghc-options:	-O2 -ignore-asserts -funbox-strict-fields
 
-executable mios-48
+executable mios-50
   hs-source-dirs:	src app
   main-is:              mios.hs
   if flag(prof)
@@ -116,7 +116,7 @@ executable mios-48
                         SAT.Mios.Vec
                         SAT.Mios
 
-executable mios-48-prof
+executable mios-50-prof
   hs-source-dirs:	src app
   main-is:              mios.hs
   if flag(prof)

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -48,7 +48,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.5.0WIP #48"
+versionId = "mios-1.5.0WIP #48 #50"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -202,7 +202,6 @@ markClause ClauseExtManager{..} c = do
   let
     seekIndex :: Int -> IO ()
     seekIndex ((< n) -> False) = do
-      print c
       cl <- map lit2int <$> asList c
       error $ "markClause failed to seek" ++ show cl
     seekIndex k = do

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -457,6 +457,9 @@ propagate s@Solver{..} = do
       incrementStat s NumOfPropagation 1
       let (ws :: ClauseExtManager) = getNthWatcher watches p
           !falseLit = negateLit p
+      cs <- mapM (\c -> take 2 <$> asList c) =<< asList ws
+      let cs' = filter (notElem falseLit) cs
+      when (cs' /= []) $ putStrLn $ show (lit2int p) ++ ":" ++ show cs
       end <- get' ws
       cvec <- getClauseVector ws
       bvec <- getKeyVector ws

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -62,8 +62,8 @@ newLearntClause s@Solver{..} ps = do
        l2 <- getNth ps 2
        let c = BiClause l1 l2
        -- inplaceSubsume s clauses c
-       -- subsumeAll s 1 c
-       -- subsumeAll s 2 c
+       subsumeAll s 1 c
+       subsumeAll s 2 c
        -- pushTo learnts c
        pushTo clauses c
        pushClauseWithKey (getNthWatcher watches (negateLit l1)) c l2

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -225,14 +225,6 @@ addClause s@Solver{..} vecLits = do
    Right c -> do
      pushTo clauses c
      tn <- get' clauses
-     when (tn == 66597 + 1) $ do
-       c' <- map lit2int <$> asList c
-       g1 <- getNth (lits c) 1
-       g2 <- getNth (lits c) 2
-       print ("addClause", (c', lit2int g1, lit2int g2), tn)
-       c1 <- checkWatch (getNthWatcher watches (negateLit g1)) c
-       c2 <- checkWatch (getNthWatcher watches (negateLit g2)) c
-       print ("watch " ++ show (lit2int (negateLit g1)), c1, "watch " ++ show (lit2int (negateLit g2)), c2)
      return True
 
 -- | __Fig. 8. (p.12)__ create a new clause and adds it to watcher lists.


### PR DESCRIPTION
### reason

`simplifyDB` clears all `watches`. Then `subsumeAll` tries to purge all subsumable clauses by calling `removeWatch` on them. Since, however, these clauses lost the registered watch literals, `markClause` called in `removeWatch` has to overrun.

### fix
by stopping `reset` all watches. It might be a shortcut as I coded. But it's a wrong logic.