### PR TITLE
Fix bugs in simplifyDB and analyze in 1.5.0

### DIFF
--- a/mios.cabal
+++ b/mios.cabal
@@ -89,7 +89,7 @@ library
   else
     ghc-options:	-O2 -ignore-asserts -funbox-strict-fields
 
-executable mios-WIP
+executable mios-52
   hs-source-dirs:	src app
   main-is:              mios.hs
   if flag(prof)
@@ -116,7 +116,7 @@ executable mios-WIP
                         SAT.Mios.Vec
                         SAT.Mios
 
-executable mios-WIP-prof
+executable mios-52-prof
   hs-source-dirs:	src app
   main-is:              mios.hs
   if flag(prof)

--- a/mios.cabal
+++ b/mios.cabal
@@ -29,10 +29,6 @@ Flag llvm
   Description:	        Compile with llvm
   Default:	        False
 
-Flag lib
-  Description:	        Build the solver library
-  Default:	        False
-
 Flag prof
   Description:	        Build the profiler
   Default:	        False
@@ -46,11 +42,7 @@ Flag utils
   Default:	        False
 
 library
-  hs-source-dirs:	.
-  if flag(lib)
-    buildable:	        True
-  else
-    buildable:	        False
+  hs-source-dirs:	src
   default-language:	Haskell2010
   default-extensions:   Strict
   other-extensions:	    BangPatterns
@@ -71,10 +63,11 @@ library
                         SAT.Mios.Clause
                         SAT.Mios.ClauseManager
                         SAT.Mios.ClausePool
-                        SAT.Mios.Vec
+                        SAT.Mios.Glucose
                         SAT.Mios.Main
                         SAT.Mios.OptionParser
                         SAT.Mios.Solver
+                        SAT.Mios.Vec
                         SAT.Mios.Types
                         SAT.Mios.Validator
                         SAT.Mios.Util.DIMACS.MinisatReader
@@ -85,87 +78,51 @@ library
                         SAT.Mios
   build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
   if flag(llvm)
-    ghc-options:	-O2 -ignore-asserts -funbox-strict-fields -fllvm -optlo-O2 -optlc-O2
+    ghc-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -optlc-O3 -fwarn-missing-signatures
   else
-    ghc-options:	-O2 -ignore-asserts -funbox-strict-fields
+    ghc-options:	-O2 -funbox-strict-fields -msse2 -fwarn-missing-signatures
 
 executable mios-52
-  hs-source-dirs:	src app
+  hs-source-dirs:	app
   main-is:              mios.hs
   if flag(prof)
     buildable:	        False
   else
     buildable:	        True
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
+  default-extensions:   Strict
+  build-depends:        base, mios
   if flag(llvm)
     ghc-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -optlc-O3 -rtsopts -fwarn-missing-signatures
   else
     ghc-options:	-O2 -funbox-strict-fields -msse2 -rtsopts -fwarn-missing-signatures
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.ClausePool
-                        SAT.Mios.Glucose
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
 
 executable mios-52-prof
-  hs-source-dirs:	src app
+  hs-source-dirs:	app
   main-is:              mios.hs
   if flag(prof)
     buildable:	        True
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
+  default-extensions:   Strict
+  build-depends:        base, mios
   if flag(llvm)
     ghc-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -prof -fprof-auto -rtsopts -ddump-simpl
   else
     ghc-options:	-O2 -funbox-strict-fields -prof -fprof-auto -rtsopts -ddump-simpl
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.ClausePool
-                        SAT.Mios.Glucose
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
 
 executable cnf-stat
-  hs-source-dirs:	src utils
+  hs-source-dirs:	utils
   main-is:              cnf-stat.hs
   if flag(utils)
     buildable:	        True
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.ClausePool
-                        SAT.Mios.Glucose
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mios-mc
   hs-source-dirs:	MultiConflict app
@@ -175,22 +132,12 @@ executable mios-mc
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
   if flag(llvm)
     ghc-options:	-O2 -ignore-asserts -funbox-strict-fields -fllvm -optlo-O2 -optlc-O2
   else
     ghc-options:	-O2 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
 
 executable mios-mc-prof
   hs-source-dirs:	MultiConflict app
@@ -200,19 +147,9 @@ executable mios-mc-prof
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >=0.12, ghc-prim >=0.5, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O2 -ignore-asserts -funbox-strict-fields -prof -fprof-auto
-  other-modules:
-                        SAT.Mios.Clause
-                        SAT.Mios.ClauseManager
-                        SAT.Mios.Main
-                        SAT.Mios.OptionParser
-                        SAT.Mios.Solver
-                        SAT.Mios.Types
-                        SAT.Mios.Validator
-                        SAT.Mios.Vec
-                        SAT.Mios
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O2 -ignore-asserts -funbox-strict-fields -prof -fprof-auto
 
 executable mc-dump2csv
   hs-source-dirs:	MultiConflict
@@ -222,13 +159,9 @@ executable mc-dump2csv
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-averagecsv
   hs-source-dirs:	MultiConflict
@@ -238,13 +171,9 @@ executable mc-averagecsv
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-summary
   hs-source-dirs:	MultiConflict
@@ -254,13 +183,9 @@ executable mc-summary
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-stat2csv
   hs-source-dirs:	MultiConflict
@@ -270,13 +195,9 @@ executable mc-stat2csv
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.11, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-pickup
   hs-source-dirs:	MultiConflict
@@ -286,13 +207,9 @@ executable mc-pickup
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields
 
 executable mc-numbers
   hs-source-dirs:	MultiConflict
@@ -302,10 +219,6 @@ executable mc-numbers
   else
     buildable:	        False
   default-language:	Haskell2010
-  default-extensions:  Strict
-  build-depends:        base >=4.10, vector >= 0.12, bytestring >=0.10, primitive >=0.6
-  ghc-options:	-O1 -ignore-asserts -funbox-strict-fields
-  other-modules:
-                        SAT.Mios.Types
-                        SAT.Mios.Util.Stat
-                        SAT.Mios.Vec
+  default-extensions:   Strict
+  build-depends:        base, mios, bytestring >=0.10
+  ghc-options:	        -O1 -ignore-asserts -funbox-strict-fields

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -48,7 +48,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.5.0WIP"
+versionId = "mios-1.5.0WIP #52fix-bugs"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ _ = return 0

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -225,7 +225,7 @@ analyze s@Solver{..} confl = do
                           r' <- get' =<< getNth reason v
                           when (r < r') $ varBumpActivity s v
                           loopOnLastDL $ i + 1
-  loopOnLastDL $ div nld 2 + 1
+  loopOnLastDL 1
   reset an'lastDL
   -- Clear seen
   k <- get' an'toClear

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -220,16 +220,12 @@ analyze s@Solver{..} confl = do
   nld <- get' an'lastDL
   first <- getNth litsLearnt 1
   setNth level (lit2var first) levelToReturn
-  r1 <- get' litsLearnt
-  r2 <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
+  r <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
-                          c <- getNth reason v
-                          r1' <- get' c
-                          r2' <- lbdOf s (lits c) -- get' (rank c)
-                          set' (rank c) r2'
-                          when ((r2' == r2 && r1' < r1) || (r2' < r2)) $ varBumpActivity s v
+                          r' <- lbdOf s . lits =<< getNth reason v
+                          when (r' < r) $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -220,12 +220,16 @@ analyze s@Solver{..} confl = do
   nld <- get' an'lastDL
   first <- getNth litsLearnt 1
   setNth level (lit2var first) levelToReturn
-  r <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
+  r1 <- get' litsLearnt
+  r2 <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
-                          r' <- lbdOf s . lits =<< getNth reason v
-                          when (r' < r) $ varBumpActivity s v
+                          c <- getNth reason v
+                          r1' <- get' c
+                          r2' <- lbdOf s (lits c) -- get' (rank c)
+                          set' (rank c) r2'
+                          when ((r2' == r2 && r1' < r1) || (r2' < r2)) $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -218,12 +218,12 @@ analyze s@Solver{..} confl = do
   loopOnLits 2 2                -- the first literal is specail
   -- glucose heuristics
   nld <- get' an'lastDL
-  r <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
+  r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
-                          r' <- lbdOf s . lits =<< getNth reason v
-                          when (r < r') $ varBumpActivity s v
+                          r' <- get' =<< getNth reason v
+                          when (r' < r) $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -225,7 +225,7 @@ analyze s@Solver{..} confl = do
                           r' <- get' =<< getNth reason v
                           when (r < r') $ varBumpActivity s v
                           loopOnLastDL $ i + 1
-  loopOnLastDL 1
+  loopOnLastDL $ div nld 2 + 1
   reset an'lastDL
   -- Clear seen
   k <- get' an'toClear

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -218,14 +218,12 @@ analyze s@Solver{..} confl = do
   loopOnLits 2 2                -- the first literal is specail
   -- glucose heuristics
   nld <- get' an'lastDL
-  first <- getNth litsLearnt 1
-  setNth level (lit2var first) levelToReturn
-  r <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
+  r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
-                          r' <- lbdOf s . lits =<< getNth reason v
-                          when (r' < r) $ varBumpActivity s v
+                          r' <- get' =<< getNth reason v
+                          when (r < r') $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -163,7 +163,7 @@ analyze s@Solver{..} confl = do
                 setNth an'seen v 1
                 if dl <= l      -- cancelUntil doesn't clear level of cancelled literals
                   then do
-                      -- glucose heuristics
+                      -- UPDATEVARACTIVITY: glucose heuristics
                       r <- getNth reason v
                       when (r /= NullClause) $ do
                         ra <- get' (rank r)
@@ -216,14 +216,14 @@ analyze s@Solver{..} confl = do
              then setNth litsLearnt j l >> loopOnLits (i + 1) (j + 1)
              else loopOnLits (i + 1) j
   loopOnLits 2 2                -- the first literal is specail
-  -- glucose heuristics
+  -- UPDATEVARACTIVITY: glucose heuristics
   nld <- get' an'lastDL
   r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
                           r' <- get' =<< getNth reason v
-                          when (r' < r) $ varBumpActivity s v
+                          when (r < r') $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -218,11 +218,11 @@ analyze s@Solver{..} confl = do
   loopOnLits 2 2                -- the first literal is specail
   -- glucose heuristics
   nld <- get' an'lastDL
-  r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
+  r <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
-                          r' <- get' =<< getNth reason v
+                          r' <- lbdOf s . lits =<< getNth reason v
                           when (r < r') $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -218,12 +218,14 @@ analyze s@Solver{..} confl = do
   loopOnLits 2 2                -- the first literal is specail
   -- glucose heuristics
   nld <- get' an'lastDL
-  r <- get' litsLearnt -- this is an estimated LBD value based on the clause size
+  first <- getNth litsLearnt 1
+  setNth level (lit2var first) levelToReturn
+  r <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
-                          r' <- get' =<< getNth reason v
-                          when (r < r') $ varBumpActivity s v
+                          r' <- lbdOf s . lits =<< getNth reason v
+                          when (r' < r) $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -220,16 +220,14 @@ analyze s@Solver{..} confl = do
   nld <- get' an'lastDL
   first <- getNth litsLearnt 1
   setNth level (lit2var first) levelToReturn
-  r1 <- get' litsLearnt
-  r2 <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
+  r <- get' litsLearnt
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
                           c <- getNth reason v
-                          r1' <- get' c
-                          r2' <- lbdOf s (lits c) -- get' (rank c)
-                          set' (rank c) r2'
-                          when ((r2' == r2 && r1' < r1) || (r2' < r2)) $ varBumpActivity s v
+                          r' <- lbdOf s (lits c)
+                          set' (rank c) r'
+                          when (r' < r) $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -220,14 +220,16 @@ analyze s@Solver{..} confl = do
   nld <- get' an'lastDL
   first <- getNth litsLearnt 1
   setNth level (lit2var first) levelToReturn
-  r <- get' litsLearnt
+  r1 <- get' litsLearnt
+  r2 <- lbdOf s litsLearnt -- this is an estimated LBD value based on the clause size
   let loopOnLastDL :: Int -> IO ()
       loopOnLastDL ((<= nld) -> False) = return ()
       loopOnLastDL i = do v <- lit2var <$> getNth an'lastDL i
                           c <- getNth reason v
-                          r' <- lbdOf s (lits c)
-                          set' (rank c) r'
-                          when (r' < r) $ varBumpActivity s v
+                          r1' <- get' c
+                          r2' <- lbdOf s (lits c) -- get' (rank c)
+                          set' (rank c) r2'
+                          when ((r2' == r2 && r1' < r1) || (r2' < r2)) $ varBumpActivity s v
                           loopOnLastDL $ i + 1
   loopOnLastDL 1
   reset an'lastDL

--- a/src/SAT/Mios/Util/BoolExp.hs
+++ b/src/SAT/Mios/Util/BoolExp.hs
@@ -67,7 +67,10 @@ numberOfVariables (Cnf (a, b) _) = a + b - tseitinBase
 numberOfClauses :: BoolForm -> Int
 numberOfClauses (Cnf _ l) = length l
 
+boolFormTrue :: BoolForm
 boolFormTrue = Cnf (-1, 1) []
+
+boolFormFalse :: BoolForm
 boolFormFalse = Cnf (-1, -1) []
 
 instance BoolComponent Bool where
@@ -186,6 +189,7 @@ disjunctionOf [] = boolFormFalse
 disjunctionOf (x:l) = foldl' (-|-) x l
 
 -- | an alias of 'disjunctionOf'
+(-|||-) :: [BoolForm] -> BoolForm
 (-|||-) = disjunctionOf
 
 -- | merge [BoolForm] by '(-&-)'
@@ -194,6 +198,7 @@ conjunctionOf [] = boolFormTrue
 conjunctionOf (x:l) = foldl' (-&-) x l
 
 -- | an alias of 'conjunctionOf'
+(-&&&-) :: [BoolForm] -> BoolForm
 (-&&&-) = conjunctionOf
 
 -- | converts a BoolForm to "[[Int]]"

--- a/src/SAT/Mios/Util/DIMACS/MinisatReader.hs
+++ b/src/SAT/Mios/Util/DIMACS/MinisatReader.hs
@@ -39,7 +39,7 @@ seqNums = do
   skipSpaces
   x <- int
   skipSpaces
-  if (x == 0) then return []  else (x :) <$> seqNums
+  if x == 0 then return []  else (x :) <$> seqNums
 
 -- |top level interface for parsing CNF
 {-# INLINE parseMinisatOutput #-}

--- a/src/SAT/Mios/Util/DIMACS/MinisatReader.hs
+++ b/src/SAT/Mios/Util/DIMACS/MinisatReader.hs
@@ -15,11 +15,13 @@ import Text.ParserCombinators.ReadP
 -- parser
 -- |parse a non-signed integer
 {-# INLINE pint #-}
+pint :: ReadP Int
 pint = do
   n <- munch isDigit
   return (read n :: Int)
 
 {-# INLINE mint #-}
+mint :: ReadP Int
 mint = do
   char '-'
   n <- munch isDigit
@@ -27,10 +29,12 @@ mint = do
 
 -- |parse a (signed) integer
 {-# INLINE int #-}
+int :: ReadP Int
 int = mint <++ pint
 
 -- |return integer list that terminates at zero
 {-# INLINE seqNums #-}
+seqNums :: ReadP [Int]
 seqNums = do
   skipSpaces
   x <- int

--- a/src/SAT/Mios/Util/DIMACS/Reader.hs
+++ b/src/SAT/Mios/Util/DIMACS/Reader.hs
@@ -14,24 +14,30 @@ import Text.ParserCombinators.ReadP
 
 -- parser
 {-# INLINE newline #-}
+newline :: ReadP Char
 newline = char '\n'
 
 {-# INLINE digit #-}
+digit :: ReadP Char
 digit = satisfy isDigit
 
 {-# INLINE spaces #-}
+spaces :: ReadP String
 spaces = munch (`elem` " \t")
 
 {-# INLINE noneOf #-}
+noneOf :: Foldable t => t Char -> ReadP Char
 noneOf s = satisfy (`notElem` s)
 
 -- |parse a non-signed integer
 {-# INLINE pint #-}
+pint :: ReadP Int
 pint = do
   n <- munch isDigit
   return (read n :: Int)
 
 {-# INLINE mint #-}
+mint :: ReadP Int
 mint = do
   char '-'
   n <- munch isDigit
@@ -39,10 +45,12 @@ mint = do
 
 -- |parse a (signed) integer
 {-# INLINE int #-}
+int :: ReadP Int
 int = mint <++ pint
 
 -- |Parse something like: p FORMAT VARIABLES CLAUSES
 {-# INLINE problemLine #-}
+problemLine :: ReadP (Int, Int)
 problemLine = do
   char 'p'
   skipSpaces
@@ -57,6 +65,7 @@ problemLine = do
 
 -- |Parse something like: c This in an example of a comment line.
 {-# INLINE commentLines #-}
+commentLines :: ReadP ()
 commentLines = do
   l <- look
   if (head l)  == 'c'
@@ -66,6 +75,7 @@ commentLines = do
       commentLines
     else return ()
 
+_commentLines :: ReadP ()
 _commentLines = do
   char 'c'
   munch ('\n' /=)
@@ -75,12 +85,14 @@ _commentLines = do
 
 -- |Parse the preamble part
 {-# INLINE preambleCNF #-}
+preambleCNF :: ReadP (Int, Int)
 preambleCNF = do
   commentLines
   problemLine
 
 -- |return integer list that terminates at zero
 {-# INLINE seqNums #-}
+seqNums :: ReadP [Int]
 seqNums = do
   skipSpaces
   x <- int
@@ -101,6 +113,7 @@ parseCNF = do
   return (a, b)
 
 -- |driver:: String -> Either ParseError Int
+driver :: String -> [([[Int]], String)]
 driver input = readP_to_S (parseClauses 1) input
 
 -- |read a CNF file and return:


### PR DESCRIPTION
### objective

- [x] fix (or optimeze) about [UPDATEVARACTIVITY trick](https://github.com/shnarazk/glucose/blob/6332016ee1296f31f8ed18d9b6a618d9cf570af0/core/Solver.cc#L714) used in Glucose 3.0
- [x] `simplifyDB` failed to remove satisfied clauses from `learnts`
- [ ] a speculation on the meaning of LBD

### related 

- glucose-3.0: https://github.com/shnarazk/glucose/pull/2
- glucose-3.0: https://github.com/shnarazk/glucose/pull/3
- glucose-3.0: https://github.com/shnarazk/glucose/pull/4

-----

Gilles Audemard, Laurent Simon, GLUCOSE : a solver that predicts learnt clauses quality, In *[SAT 2009 competitive events booklet: preliminary version](http://www.cril.univ-artois.fr/SAT09/solvers/booklet.pdf)*, 2009.

>The state-of-the-art VSIDS [Moskewicz et al., 2001] heuristic bumps all variables which participated to the resolution steps conducting to the assertive clause. This heuristic favors variables that are often and recently used in conflict analysis. Since we want to help the solver to generate clauses with
small LBD values, we propose to reward ***a second time variables that help to obtain such clauses***.

> We bump once again all variables from the last decision level, which were used in conflict analysis, but which were propagated by a clause of small LBD (smaller than the new learnt clause).

#### the criterion based on 1.5.0

```
# sat-benchmark 0.13.2, j=1, t=1260, p='' on smithi @ 2017-11-01T01:32:12+09:00
"mios-1.5.0", 1, 175,    3.61
"mios-1.5.0", 2, 200,    9.72
"mios-1.5.0", 3, 225,    26.56
"mios-1.5.0", 4, 250,    64.66
"mios-1.5.0", 5, "itox",         10.86
"mios-1.5.0", 6, "m283",         24.14
"mios-1.5.0", 7, "38b",  30.03
"mios-1.5.0", 8, "48b",  38.83
```