### PR TITLE
A new clause criterion

### DIFF
--- a/app/mios.hs
+++ b/app/mios.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-   MultiWayIf
+    MultiWayIf
+  , TemplateHaskell
   #-}
 -- | Executable of 'Minisat Implementation and Optimization Study'
 module Main
@@ -9,14 +10,18 @@ module Main
        where
 
 import SAT.Mios
+import Development.GitRev
+
+gitId :: String
+gitId = versionId ++ "/commit/" ++ $(gitHash)
 
 usage :: String
-usage = miosUsage $ versionId ++ "\nUsage: mios [OPTIONS] target.cnf"
+usage = miosUsage $ gitId ++ "\nUsage: mios [OPTIONS] target.cnf"
 
 -- | main
 main :: IO ()
 main = do opts <- miosParseOptionsFromArgs versionId
-          if | _displayVersion opts        -> putStrLn versionId
+          if | _displayVersion opts        -> putStrLn gitId
              | _displayHelp opts           -> putStrLn usage
              | _targetFile opts == Nothing -> putStrLn usage
              | _validateAssignment opts    -> executeValidator opts

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-75:
+  mios-74:
     source-dirs:     app
     main:            mios.hs
     dependencies:    mios

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-74-revert:
+  mios-74-altitude:
     source-dirs:     app
     main:            mios.hs
     dependencies:    mios

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-74-horizon:
+  mios-74-revert:
     source-dirs:     app
     main:            mios.hs
     dependencies:    mios

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-74:
+  mios-74-horizon:
     source-dirs:     app
     main:            mios.hs
     dependencies:    mios

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-73:
+  mios-75:
     source-dirs:     app
     main:            mios.hs
     dependencies:    mios

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-77:
+  mios-76:
     source-dirs:     app
     main:            mios.hs
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -41,21 +41,33 @@ dependencies:
   - primitive >=0.6
   - bytestring >=0.10
   - vector >=0.12
-
 library:
   source-dirs:       src
 
 executables:
-  mios-74-altitude:
+  mios-77:
     source-dirs:     app
     main:            mios.hs
-    dependencies:    mios
+    dependencies:
+      - mios
+      - gitrev
     when:
       - condition: flag(llvm)
         then:
           ghc-prof-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -fprof-auto -rtsopts
+                                --rtsopts-with="-H16M -A16M"
         else:
           ghc-prof-options:	-O2 -funbox-strict-fields -fprof-auto -rtsopts
+  cnf-stat:
+    source-dirs:     utils
+    main:            cnf-stat.hs
+    dependencies:    mios
+    when:
+      - condition:   flag(utils)
+        then:
+          buildable: true
+        else:
+          buildable: false
   cnf-stat:
     source-dirs:     utils
     main:            cnf-stat.hs

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.6.1WIP#72#73 -- https://github.com/shnarazk/mios"
+versionId = "mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.6.1WIP#72 #73 -- https://github.com/shnarazk/mios"
+versionId = "mios-1.6.1WIP#72#73 -- https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios"
+versionId = "mios-1.6.1WIP#72#73#74#77#78 -- https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0
@@ -73,11 +73,15 @@ executeSolverOn path = executeSolver (miosDefaultOption { _targetFile = Just pat
 -- This is another entry point for standalone programs.
 executeSolver :: MiosProgramOption -> IO ()
 executeSolver opts@(_targetFile -> (Just cnfFile)) = do
-  t0 <- reportElapsedTime False "" $ if _confVerbose opts || 0 <= _confBenchmark opts then -1 else 0
+  solverId <- myThreadId
   (desc, cls) <- parseCNF (_targetFile opts)
   -- when (_numberOfVariables desc == 0) $ error $ "couldn't load " ++ show cnfFile
+  when (_confMaxClauses opts < _numberOfClauses desc) $
+    if -1 == _confBenchmark opts
+      then errorWithoutStackTrace $ "ABORT: too many clauses to solve, " ++ show desc
+      else reportResult opts 0 (Left OutOfMemory) >> killThread solverId
   token <- newEmptyMVar --  :: IO (MVar (Maybe Solver))
-  solverId <- myThreadId
+  t0 <- reportElapsedTime False "" $ if _confVerbose opts || 0 <= _confBenchmark opts then -1 else 0
   handle (\case
              UserInterrupt -> putStrLn "User interrupt recieved."
              ThreadKilled  -> reportResult opts t0 =<< readMVar token
@@ -87,13 +91,13 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
                          threadDelay $ fromMicro * fromIntegral (_confBenchmark opts)
                          putMVar token (Left TimeOut)
                          killThread solverId
-    when (_confMaxSize opts < _numberOfVariables desc) $
-      if -1 == _confBenchmark opts
-        then errorWithoutStackTrace $ "ABORT: too many variables to solve, " ++ show desc
-        else putMVar token (Left OutOfMemory) >> killThread solverId
     s <- newSolver (toMiosConf opts) desc
+    -- ct <- reportElapsedTime True "- making a new solver: " t0
     injectClausesFromCNF s desc cls
     void $ reportElapsedTime (_confVerbose opts) ("## [" ++ showPath cnfFile ++ "] Parse: ") t0
+    -- putMVar token (Left TimeOut)
+    -- killThread solverId
+    -- ct <- reportElapsedTime True "injecting w/ ByteString: " ct
     when (0 < _confDumpStat opts) $ dumpStats DumpCSVHeader s
     result <- solve s []
     putMVar token result
@@ -125,7 +129,7 @@ reportResult opts@(_targetFile -> Just cnfFile) t0 (Right result) = do
     UNSAT t -> do when (_confVerbose opts) $ hPutStrLn stderr "UNSAT" -- contradiction
                   print t
   dumpAssigmentAsCNF (_outputFile opts) result
-  valid <- if _confCheckAnswer opts || 0 <= _confBenchmark opts
+  valid <- if _confCheckAnswer opts -- || 0 <= _confBenchmark opts
            then case result of
                   SAT asg -> do (desc, cls) <- parseCNF (_targetFile opts)
                                 s' <- newSolver (toMiosConf opts) desc
@@ -241,6 +245,13 @@ dumpAssigmentAsCNF (Just fname) (UNSAT _) =
 dumpAssigmentAsCNF (Just fname) (SAT l) =
   withFile fname WriteMode $ \h -> do hPutStrLn h "s SAT"; hPutStrLn h . (++ " 0") . unwords $ map show l
 
+showPath :: FilePath -> String
+showPath str = replicate (len - length basename) ' ' ++ if elem '/' str then basename else basename'
+  where
+    len = 50
+    basename = reverse . takeWhile (/= '/') . reverse $ str
+    basename' = take len str
+
 --------------------------------------------------------------------------------
 -- DIMACS CNF Reader
 --------------------------------------------------------------------------------
@@ -253,37 +264,30 @@ parseCNF target@(Just cnfFile) = do
                       (x, second) -> case B.readInt (skipWhitespace second) of
                                        Just (y, _) -> CNFDescription x y target
       seek :: B.ByteString -> IO (CNFDescription, B.ByteString)
-      seek bs
+      seek !bs
         | B.head bs == 'p' = return (parseP l, B.tail bs')
         | otherwise = seek (B.tail bs')
         where (l, bs') = B.span ('\n' /=) bs
   seek =<< B.readFile cnfFile
 
 -- | parses ByteString then injects the clauses in it into a solver
+{-# INLINABLE injectClausesFromCNF #-}
 injectClausesFromCNF :: Solver -> CNFDescription -> B.ByteString -> IO ()
 injectClausesFromCNF s (CNFDescription nv nc _) bs = do
   let maxLit = int2lit $ negate nv
-  buffer <- newVec (maxLit + 1) 0
-  polvec <- newVec (maxLit + 1) 0
+  buffer <- newVec (maxLit + 1) 0 :: IO (Vec Int)
   let loop :: Int -> B.ByteString -> IO ()
       loop ((< nc) -> False) _ = return ()
-      loop !i !b = loop (i + 1) =<< readClause s buffer polvec b
+      loop !i !b = loop (i + 1) =<< readClause s buffer b
   loop 0 bs
-  -- static polarity
-  let checkPolarity :: Int -> IO ()
-      checkPolarity ((< nv) -> False) = return ()
-      checkPolarity v = do
-        p <- getNth polvec $ var2lit v True
-        if p == LiftedF
-          then setAssign s v p
-          else do n <- getNth polvec $ var2lit v False
-                  when (n == LiftedF) $ setAssign s v p
-        checkPolarity $ v + 1
-  checkPolarity 1
 
 {-# INLINE skipWhitespace #-}
 skipWhitespace :: B.ByteString -> B.ByteString
-skipWhitespace !s = B.dropWhile (`elem` " \t\n") s
+skipWhitespace !s = B.dropWhile (== ' ') {- (`elem` " \t") -} s
+
+{-# INLINE skipWhitespace' #-}
+skipWhitespace' :: B.ByteString -> B.ByteString
+skipWhitespace' !s = B.dropWhile (`elem` " \t\n") s
 
 -- | skip comment lines
 -- __Pre-condition:__ we are on the benngining of a line
@@ -295,41 +299,27 @@ skipComments !s
   where
     c = B.head s
 
-{-# INLINABLE parseInt #-}
+{-# INLINE parseInt #-}
 parseInt :: B.ByteString -> (Int, B.ByteString)
 parseInt !st = do
   let !zero = ord '0'
       loop :: B.ByteString -> Int -> (Int, B.ByteString)
-      loop !s !val = case B.head s of
-        c | '0' <= c && c <= '9'  -> loop (B.tail s) (val * 10 + ord c - zero)
-        _ -> (val, B.tail s)
-  case B.head st of
-    '-' -> let (k, x) = loop (B.tail st) 0 in (negate k, x)
-    '0' -> (0, B.tail st)
---    '+' -> loop st (0 :: Int)
-    _   -> loop st 0
---    c | '0' <= c && c <= '9'  -> loop st 0
---    _ -> error "PARSE ERROR! Unexpected char"
+      loop !s !val = case B.uncons s of
+        Just (c, s') -> if '0' <= c && c <= '9' then loop s' (val * 10 + ord c - zero) else (val, s')
+  case B.uncons st of
+    Just ('-', st') -> let (k, x) = loop st' 0 in (negate k, x)
+    Just ('0', st') -> (0, st')
+    _ -> loop st 0
 
-{-# INLINABLE readClause #-}
-readClause :: Solver -> Stack -> Vec Int -> B.ByteString -> IO B.ByteString
-readClause s buffer bvec stream = do
-  let
-    loop :: Int -> B.ByteString -> IO B.ByteString
-    loop !i !b = case parseInt $ skipWhitespace b of
-                   (0, b') -> do setNth buffer 0 $ i - 1
-                                 sortStack buffer
-                                 void $ addClause s buffer
-                                 return b'
-                   (k, b') -> case int2lit k of
-                                l -> do setNth buffer i l
-                                        setNth bvec l LiftedT
+{-# INLINE readClause #-}
+readClause :: Solver -> Stack {- -> Vec Int -} -> B.ByteString -> IO B.ByteString
+readClause s buffer {- bvec -} stream = do
+  let loop :: Int -> B.ByteString -> IO B.ByteString
+      loop !i !b = case parseInt $ skipWhitespace b of
+                     (k, b') -> if k == 0
+                                then do setNth buffer 0 $ i - 1
+                                        void $ addClause s buffer
+                                        return b'
+                                else do setNth buffer i (int2lit k)
                                         loop (i + 1) b'
-  loop 1 . skipComments . skipWhitespace $ stream
-
-showPath :: FilePath -> String
-showPath str = replicate (len - length basename) ' ' ++ if elem '/' str then basename else basename'
-  where
-    len = 50
-    basename = reverse . takeWhile (/= '/') . reverse $ str
-    basename' = take len str
+  loop 1 . skipComments . skipWhitespace' $ stream

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -99,7 +99,7 @@ data ClauseExtManager = ClauseExtManager
     _nActives     :: !Int'                         -- number of active clause
   , _purged       :: !Bool'                        -- whether it needs gc
   , _clauseVector :: IORef.IORef C.ClauseVector    -- clause list
-  , _keyVector    :: IORef.IORef (Vec [Int])     -- Int list
+  , _keyVector    :: IORef.IORef (Vec Int)         -- Int list
   }
 
 -- | 'ClauseExtManager' is a 'SingleStorage` on the number of clauses in it.
@@ -120,7 +120,7 @@ instance StackFamily ClauseExtManager C.Clause where
     !b <- IORef.readIORef _keyVector
     if MV.length v - 1 <= n
       then do
-          let len = max 8 $ MV.length v
+          let len = max 8 $ div (MV.length v) 2
           v' <- MV.unsafeGrow v len
           b' <- growBy b len
           MV.unsafeWrite v' n c
@@ -228,7 +228,7 @@ purifyManager ClauseExtManager{..} = do
 
 -- | returns the associated Int vector, which holds /blocking literals/.
 {-# INLINE getKeyVector #-}
-getKeyVector :: ClauseExtManager -> IO (Vec [Int])
+getKeyVector :: ClauseExtManager -> IO (Vec Int)
 getKeyVector ClauseExtManager{..} = IORef.readIORef _keyVector
 
 -- | O(1) inserter
@@ -241,7 +241,7 @@ pushClauseWithKey ClauseExtManager{..} !c k = do
   !b <- IORef.readIORef _keyVector
   if MV.length v - 1 <= n
     then do
-        let len = max 8 $ MV.length v
+        let len = max 8 $ div (MV.length v) 2
         v' <- MV.unsafeGrow v len
         b' <- growBy b len
         MV.unsafeWrite v' n c
@@ -277,7 +277,10 @@ type WatcherList = V.Vector ClauseExtManager
 -- | For /n/ vars, we need [0 .. 2 + 2 * n - 1] slots, namely /2 * (n + 1)/-length vector
 -- FIXME: sometimes n > 1M
 newWatcherList :: Int -> Int -> IO WatcherList
-newWatcherList n m = V.replicateM (int2lit (negate n) + 2) (newManager m)
+newWatcherList n m = do let n' = int2lit (negate n) + 2
+                        v <- MV.unsafeNew n'
+                        mapM_  (\i -> MV.unsafeWrite v i =<< newManager m) [0 .. n' - 1]
+                        V.unsafeFreeze v
 
 -- | returns the watcher List for "Literal" /l/.
 {-# INLINE getNthWatcher #-}

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -340,17 +340,14 @@ updateNDD s@Solver{..} = do
 nddOf :: Solver -> Stack -> IO Int
 nddOf Solver{..} stack = do
   n <- get' stack
-  let loop :: Int -> Int -> Int -> Int -> IO Int -- var -> #unassigns -> #lowbits -> #highbits
-      loop ((<= n) -> False) u low high = return $ u + popCount low + popCount high
-      loop i u low high = do v <- lit2var <$> getNth stack i
-                             a <- getNth assigns v
-                             if a == LBottom
-                               then loop (i + 1) (u + 1) low high
-                               else do let iv = varBit2vIndex v 0
-                                       l <- getNth ndd iv
-                                       h <- getNth ndd (iv + 1)
-                                       loop (i + 1) u (low .|. l) (high .|. h)
-  max 1 <$> loop 1 0 0 0
+  let loop :: Int -> Int -> Int -> IO Int -- var -> #lowbits -> #highbits
+      loop ((<= n) -> False) low high = return $ popCount low + popCount high
+      loop i low high = do v <- lit2var <$> getNth stack i
+                           let iv = varBit2vIndex v 0
+                           l <- getNth ndd iv
+                           h <- getNth ndd (iv + 1)
+                           loop (i + 1) (low .|. l) (high .|. h)
+  max 1 <$> loop 1 0 0
 
 {-
 {-# INLINABLE ndlOf #-}

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -282,8 +282,8 @@ updateNdlOf s@Solver{..} v Clause{..} = do
   let loop :: Int -> Int -> IO Int
       loop ((<= n) -> False) k = return k
       loop i k = do v <- lit2var <$> getNth lits i
-                    a <- getNth assigns v
-                    when (a == LBottom) $ error "unprepared path"
+                    -- a <- getNth assigns v
+                    -- when (a == LBottom) $ error "unprepared path"
                     loop (i + 1) . (k .|.) =<< getNth ndl v
   setNth ndl v =<< loop 1 0
 
@@ -300,7 +300,6 @@ ndlOf Solver{..} stack = do
                         then loop (i + 1) (u + 1) k
                         else loop (i + 1) u . (k .|.) =<< getNth ndl v
   loop 1 0 0
-
 
 -------------------------------------------------------------------------------- restart
 

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -386,11 +386,10 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> lrs) =
   ds <- rescaleSlow <$> revise emaDSlow (1 / fromIntegral cs) lbd
   af <- revise emaAFast (1 / fromIntegral cf) nas
   as <- rescaleSlow <$> revise emaASlow (1 / fromIntegral cs) nas
+  void $ {- rs <- rescaleSlow <$> -} revise emaRSlow (1 / fromIntegral cs) lrs
   when (0 < dumpSolverStatMode config) $ do
     void $ {- rf <-                 -} revise emaRFast (1 / fromIntegral cf) lrs
-    void $ {- rs <- rescaleSlow <$> -} revise emaRSlow (1 / fromIntegral cs) lrs
     void $ {- lf <-                 -} revise emaLFast (1 / fromIntegral cf) lvl
-    void $ {- ls <- rescaleSlow <$> -} revise emaLSlow (1 / fromIntegral cs) lvl
   let step = restartExpansionS config
   if | count < next   -> return False
      | 1.25 * as < af -> do     -- -| BLOCKING RESTART |
@@ -399,6 +398,7 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> lrs) =
          let gef = restartExpansionB config
          set' nextRestart $ count + ceiling (step + gef ** ki)
          -- set' nextRestart $ count + ceiling (step + 10 * logBase gef ki)
+         void $ {- ls <- rescaleSlow <$> -} revise emaLSlow (1 / fromIntegral cs) lvl
          when (3 == dumpSolverStatMode config) $ dumpStats DumpCSV s
          return False
      | 1.25 * ds < df -> do     -- | FORCING RESTART  |
@@ -407,6 +407,7 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> lrs) =
          let gef = restartExpansionF config
          set' nextRestart $ count + ceiling (step + gef ** ki)
          -- set' nextRestart $ count + ceiling (step + 10 * logBase gef ki)
+         void $ {- ls <- rescaleSlow <$> -} revise emaLSlow (1 / fromIntegral cs) 0
          when (3 == dumpSolverStatMode config) $ dumpStats DumpCSV s
          return True
      | otherwise      -> return False

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -283,12 +283,12 @@ varBit2bIndex v b = mod b 62
 
 -- | updates a /var/'s ndl, which is assigned by a 'reason' /clause/
 {-# INLINE updateNddOf #-}
-updateNddOf :: Solver -> Var -> Clause -> IO ()
-updateNddOf Solver{..} v NullClause = do
+updateNddOf :: Solver -> Int -> Var -> Clause -> IO ()
+updateNddOf Solver{..} thr v NullClause = do
   l <- getNth level v
-  setNth ndd (varBit2vIndex v l) $ if 0 == l then 0 else setBit 0 (varBit2bIndex v l)
+  setNth ndd (varBit2vIndex v l) $ if l <= thr then 0 else setBit 0 (varBit2bIndex v l)
 
-updateNddOf Solver{..} v Clause{..} = do
+updateNddOf Solver{..} _ v Clause{..} = do
   n <- get' lits
   let iv = varBit2vIndex v 0
   setNth ndd iv 0
@@ -324,11 +324,14 @@ updateNdlOf Solver{..} v Clause{..} = do
 {-# INLINABLE updateNDD #-}
 updateNDD :: Solver -> IO ()
 updateNDD s@Solver{..} = do
+  ns <- get' emaScale
+  lv <- get' emaLSlow
   n <- get' trail
-  let update :: Int -> IO ()
+  let thr = if ns == 0 then 0 else floor . logBase 2 $ lv / ns :: Int
+      update :: Int -> IO ()
       update ((<= n) -> False) = return ()
       update i = do v <- lit2var <$> getNth trail i
-                    updateNddOf s v =<< getNth reason v
+                    updateNddOf s thr v =<< getNth reason v
                     update (i + 1)
   update 1
 
@@ -347,7 +350,7 @@ nddOf Solver{..} stack = do
                                        l <- getNth ndd iv
                                        h <- getNth ndd (iv + 1)
                                        loop (i + 1) u (low .|. l) (high .|. h)
-  loop 1 0 0 0
+  max 1 <$> loop 1 0 0 0
 
 {-
 {-# INLINABLE ndlOf #-}

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -375,13 +375,13 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> cLv) =
   ds  <- updateEMA emaDSlow lbd
   af  <- updateEMA emaAFast nas
   as  <- updateEMA emaASlow nas
-  void $ updateEMA emaCSlow cLv
+  void $ updateEMA emaCFast cLv
   let filled = next <= count
       blockingRestart = filled && 1.25 * as < af
       forcingRestart = filled && 1.25 * ds < df
-  void $ updateEMA emaBSlow (if forcingRestart then 0 else bLv)
-  when (0 < dumpSolverStatMode config) $ do void $ updateEMA emaCFast cLv
-                                            void $ updateEMA emaBFast (if forcingRestart then 0 else bLv)
+  void $ updateEMA emaBFast (if forcingRestart then 0 else bLv)
+  when (0 < dumpSolverStatMode config) $ do void $ updateEMA emaCSlow cLv
+                                            void $ updateEMA emaBSlow (if forcingRestart then 0 else bLv)
   if (not blockingRestart && not forcingRestart)
     then return False
     else do incrementStat s (if blockingRestart then NumOfBlockRestart else NumOfRestart) 1

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -372,7 +372,7 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> cLv) =
   nas <- fromIntegral <$> nAssigns s
   bLv <- fromIntegral <$> decisionLevel s
   df  <- updateEMA emaDFast lbd
-  ds  <- updateEMA emaASlow lbd
+  ds  <- updateEMA emaDSlow lbd
   af  <- updateEMA emaAFast nas
   as  <- updateEMA emaASlow nas
   void $ updateEMA emaCSlow cLv

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -1,7 +1,8 @@
 -- | (This is a part of MIOS.)
 -- Advanced heuristics library for 'SAT.Mios.Main'
 {-# LANGUAGE
-    MultiWayIf
+    BangPatterns
+  , MultiWayIf
   , RecordWildCards
   , ViewPatterns
   #-}
@@ -136,99 +137,39 @@ claRescaleActivityAfterRestart Solver{..} = do
 -- * @Left True@ if the clause is satisfied
 -- * @Right clause@ if the clause is enqueued successfully
 {-# INLINABLE clauseNew #-}
-clauseNew :: Solver -> Stack -> Bool -> IO (Either Bool Clause)
-clauseNew s@Solver{..} ps isLearnt = do
-  -- now ps[0] is the number of living literals
-  exit <- do
-    let
-      handle :: Int -> Int -> Int -> IO Bool
-      handle j l n      -- removes duplicates, but returns @True@ if this clause is satisfied
-        | j > n = return False
-        | otherwise = do
-            y <- getNth ps j
-            if | y == l    -> do                      -- finds a duplicate
-                   swapBetween ps j n
-                   modifyNth ps (subtract 1) 0
-                   handle j l (n - 1)
-               | - y == l  -> reset ps >> return True -- p and negateLit p occurs in ps
-               | otherwise -> handle (j + 1) l n
-      loopForLearnt :: Int -> IO Bool
-      loopForLearnt i = do
-        n <- get' ps
-        if n < i
-          then return False
-          else do
-              l <- getNth ps i
-              sat <- handle (i + 1) l n
-              if sat
-                then return True
-                else loopForLearnt $ i + 1
-      loop :: Int -> IO Bool
-      loop i = do
-        n <- get' ps
-        if n < i
-          then return False
-          else do
-              l <- getNth ps i     -- check the i-th literal's satisfiability
-              sat <- valueLit s l  -- any literal in ps is true
-              case sat of
-               1  -> reset ps >> return True
-               -1 -> do
-                 swapBetween ps i n
-                 modifyNth ps (subtract 1) 0
-                 loop i
-               _ -> do
-                 sat' <- handle (i + 1) l n
-                 if sat'
-                   then return True
-                   else loop $ i + 1
-    if isLearnt then loopForLearnt 1 else loop 1
+clauseNew :: Solver -> Stack -> IO (Either Bool Clause)
+clauseNew s@Solver{..} ps = do
+  n <- get' ps
+  sortStack ps
+  let loop :: Int -> Int -> Lit -> IO Bool
+      loop ((<= n) -> False) j _ = setNth ps 0 (j - 1) >> return False
+      loop !i !j !l' = do l <- getNth ps i -- check the i-th literal's satisfiability
+                          sat <- valueLit s l
+                          if | sat == LiftedT || negateLit l == l' -> reset ps >> return True
+                             | sat /= LiftedF && l /= l' -> setNth ps j l >> loop (i + 1) (j + 1) l
+                             | otherwise -> loop (i + 1) j l'
+  exit <- loop 1 1 LBottom
   k <- get' ps
   case k of
    0 -> return (Left exit)
-   1 -> do
-     l <- getNth ps 1
-     Left <$> enqueue s l NullClause
-   _ -> do
-    -- allocate clause:
-     c <- newClauseFromStack isLearnt ps
-     let lstack = lits c
-     when isLearnt $ do
-       -- Pick a second literal to watch:
-       let
-         findMax :: Int -> Int -> Int -> IO Int
-         findMax ((<= k) -> False) j _ = return j
-         findMax i j val = do
-           v' <- lit2var <$> getNth lstack i
-           varBumpActivity s v' -- this is a just good chance to bump activities of literals in this clause
-           a <- getNth assigns v'
-           b <- getNth level v'
-           if (a /= LBottom) && (val < b)
-             then findMax (i + 1) i b
-             else findMax (i + 1) j val
-       -- Let @max_i@ be the index of the literal with highest decision level
-       max_i <- findMax 1 1 0
-       swapBetween lstack 2 max_i
-       -- check literals occurences
-       -- x <- asList c
-       -- unless (length x == length (nub x)) $ error "new clause contains a element doubly"
-       -- Bumping:
-       claBumpActivity s c -- newly learnt clauses should be considered active
-     -- Add clause to watcher lists:
-     l1 <- getNth lstack 1
-     l2 <- getNth lstack 2
-     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c 0
-     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c 0
-     return (Right c)
+   1 -> do l <- getNth ps 1
+           Left <$> enqueue s l NullClause
+   _ -> do c <- newClauseFromStack False ps
+           let lstack = lits c
+           l1 <- getNth lstack 1
+           l2 <- getNth lstack 2
+           pushClauseWithKey (getNthWatcher watches (negateLit l1)) c 0
+           pushClauseWithKey (getNthWatcher watches (negateLit l2)) c 0
+           return (Right c)
 
 -- | returns @False@ if a conflict has occured.
--- This function is called only before the solving phase to register the given clauses.
+-- This function is called only before the solving phase to register the given clauses (not learnt).
 {-# INLINABLE addClause #-}
 addClause :: Solver -> Stack -> IO Bool
 addClause s@Solver{..} vecLits = do
-  result <- clauseNew s vecLits False
+  result <- clauseNew s vecLits
   case result of
-   Left b  -> return b   -- No new clause was returned becaues a confilct occured or the clause is a literal
+   Left b  -> return b -- No clause is returned becaues a confilct occured or the clause is a literal
    Right c -> pushTo clauses c >> return True
 
 -------------------------------------------------------------------------------- Clause Metrics
@@ -375,14 +316,12 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> cLv) =
   ds  <- updateEMA emaDSlow lbd
   af  <- updateEMA emaAFast nas
   as  <- updateEMA emaASlow nas
-  void $ updateEMA emaCFast cLv
+  void $ updateEMA emaCDLvl cLv
   let filled = next <= count
       blockingRestart = filled && 1.25 * as < af
       forcingRestart = filled && 1.25 * ds < df
       lv' = if forcingRestart then 0 else bLv
-  void $ updateEMA emaBFast lv'
-  when (0 < dumpSolverStatMode config) $ do void $ updateEMA emaCSlow cLv
-                                            void $ updateEMA emaBSlow lv'
+  void $ updateEMA emaBDLvl lv'
   if (not blockingRestart && not forcingRestart)
     then return False
     else do incrementStat s (if blockingRestart then NumOfBlockRestart else NumOfRestart) 1
@@ -398,10 +337,8 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> cLv) =
 emaLabels :: [(String, Solver -> EMA)]
 emaLabels = [ ("emaAFast", emaAFast)
             , ("emaASlow", emaASlow)
-            , ("emaBFast", emaBFast)
-            , ("emaBSlow", emaBSlow)
-            , ("emaCFast", emaCFast)
-            , ("emaCSlow", emaCSlow)
+            , ("emaBDLvl", emaBDLvl)
+            , ("emaCDLvl", emaCDLvl)
             , ("emaDFast", emaDFast)
             , ("emaDSlow", emaDSlow)
             ]

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -272,7 +272,7 @@ updateLBD s c@Clause{..} = do
 -- | returns a vector index of NDD for the nth bit of a var
 {-# INLINE varBit2vIndex #-}
 varBit2vIndex :: Int -> Int -> Int
-varBit2vIndex v b
+varBit2vIndex v ((`mod` 124) -> b)
   | 62 <= b   = 2 * v + 1
   | otherwise = 2 * v
 

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -379,9 +379,10 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> cLv) =
   let filled = next <= count
       blockingRestart = filled && 1.25 * as < af
       forcingRestart = filled && 1.25 * ds < df
-  void $ updateEMA emaBFast (if forcingRestart then 0 else bLv)
+      lv' = if forcingRestart then 0 else bLv
+  void $ updateEMA emaBFast lv'
   when (0 < dumpSolverStatMode config) $ do void $ updateEMA emaCSlow cLv
-                                            void $ updateEMA emaBSlow (if forcingRestart then 0 else bLv)
+                                            void $ updateEMA emaBSlow lv'
   if (not blockingRestart && not forcingRestart)
     then return False
     else do incrementStat s (if blockingRestart then NumOfBlockRestart else NumOfRestart) 1

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -283,12 +283,12 @@ varBit2bIndex v b = mod b 62
 
 -- | updates a /var/'s ndl, which is assigned by a 'reason' /clause/
 {-# INLINE updateNddOf #-}
-updateNddOf :: Solver -> Int -> Var -> Clause -> IO ()
-updateNddOf Solver{..} thr v NullClause = do
+updateNddOf :: Solver -> Var -> Clause -> IO ()
+updateNddOf Solver{..} v NullClause = do
   l <- getNth level v
-  setNth ndd (varBit2vIndex v l) $ if l <= thr then 0 else setBit 0 (varBit2bIndex v l)
+  setNth ndd (varBit2vIndex v l) $ if l == 0 then 0 else setBit 0 (varBit2bIndex v l)
 
-updateNddOf Solver{..} _ v Clause{..} = do
+updateNddOf Solver{..} v Clause{..} = do
   n <- get' lits
   let iv = varBit2vIndex v 0
   setNth ndd iv 0
@@ -324,14 +324,12 @@ updateNdlOf Solver{..} v Clause{..} = do
 {-# INLINABLE updateNDD #-}
 updateNDD :: Solver -> IO ()
 updateNDD s@Solver{..} = do
-  ns <- get' emaScale
-  lv <- get' emaLSlow
   n <- get' trail
-  let thr = if ns == 0 then 0 else floor . logBase 2 $ lv / ns :: Int
+  let -- thr = if ns == 0 then 0 else floor . logBase 2 $ lv / ns :: Int
       update :: Int -> IO ()
       update ((<= n) -> False) = return ()
       update i = do v <- lit2var <$> getNth trail i
-                    updateNddOf s thr v =<< getNth reason v
+                    updateNddOf s v =<< getNth reason v
                     update (i + 1)
   update 1
 

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -521,7 +521,9 @@ sortClauses s cm limit' = do
           else do a <- get' (activity c)               -- Second one... based on LBD
                   rLBD <- fromIntegral <$> get' (rank c)       -- above the level
                   rNDD <- fromIntegral <$> nddOf s (lits c)    -- under the level
-                  let r = ceiling . logBase 2 $ rLBD ** fillRate * rNDD ** (1 - fillRate)
+                  let r = if rNDD == 1                         -- this implies rLBD == 1.
+                          then 1
+                          else ceiling . logBase 2 $ rLBD ** fillRate * rNDD ** (1 - fillRate)
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -499,7 +499,7 @@ sortClauses s cm limit' = do
   keys <- newVec (2 * n) 0 :: IO (Vec Int)
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
-  updateNDL s
+  updateNDD s
   let shiftLBD = activityWidth
       shiftIndex = shiftL 1 indexWidth
       am = fromIntegral activityMax :: Double
@@ -518,7 +518,7 @@ sortClauses s cm limit' = do
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)               -- Second one... based on LBD
                   r_ <- get' (rank c)
-                  r' <- ndlOf s (lits c)
+                  r' <- nddOf s (lits c)
 --                  let r = 3 * r_
                   let r = ceiling . sqrt . fromIntegral $ r_ * r'
                   l <- locked s c

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -520,7 +520,7 @@ sortClauses s cm limit' = do
                   r_ <- get' (rank c)
                   r' <- nddOf s (lits c)
 --                  let r = 3 * r_
-                  let r = ceiling . sqrt . fromIntegral $ r_ * r'
+                  let r = r' -- ceiling . sqrt . fromIntegral $ r_ * r'
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -84,6 +84,8 @@ newLearntClause s@Solver{..} ps = do
            unsafeEnqueue s l1 c
            -- Since unsafeEnqueue updates the 1st literal's level, setLBD should be called after unsafeEnqueue
            r <- ndlOf s (lits c)          -- lbdOf s (lits c)
+           -- l <- lbdOf s (lits c)
+           -- putStrLn $ show k ++ "," ++ show l ++ "," ++ show r
            set' (rank c) r
            -- assert (0 < rank c)
            -- set' (protected c) True

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -500,6 +500,9 @@ sortClauses s cm limit' = do
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
   updateNDD s
+  rl <- get' (emaLSlow s)
+  cl <- get' (emaRSlow s)
+  let iceburg = min 1 . max 0 $ rl / cl :: Double -- restart level / coflict level < 1.0
   let shiftLBD = activityWidth
       shiftIndex = shiftL 1 indexWidth
       am = fromIntegral activityMax :: Double
@@ -517,11 +520,11 @@ sortClauses s cm limit' = do
           then do setNth keys (2 * i) 0
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)               -- Second one... based on LBD
---                  r_ <- get' (rank c)
-                  r_ <- get' (lits c)
+                  r_ <- get' (rank c)
+--                  r_ <- get' (lits c)
                   r' <- nddOf s (lits c)
---                  let r = 3 * r_
-                  let r = ceiling . sqrt . fromIntegral $ r_ * r'
+--                  let r = ceiling . sqrt . fromIntegral $ r_ * r'
+                  let r = ceiling $ fromIntegral r_ * iceburg + fromIntegral r' * (1 - iceburg)
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -500,8 +500,8 @@ sortClauses s cm limit' = do
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
   updateNDD s
-  cl <- getEMA (emaCSlow s)
-  fillRate <- if cl == 0 then return 0 else (/ cl) <$> getEMA (emaBSlow s)  -- 0 <=backjumped level / coflict level < 1.0
+  cl <- getEMA (emaCFast s)
+  surface <- if cl == 0 then return 0 else (/ cl) <$> getEMA (emaBFast s)  -- 0 <=backjumped level / coflict level < 1.0
   let shiftLBD = activityWidth
       shiftIndex = shiftL 1 indexWidth
       am = fromIntegral activityMax :: Double
@@ -523,7 +523,7 @@ sortClauses s cm limit' = do
                   rNDD <- fromIntegral <$> nddOf s (lits c)    -- under the level
                   let r = if rNDD == 1                         -- this implies rLBD == 1.
                           then 1
-                          else ceiling . logBase 2 $ rLBD ** fillRate * rNDD ** (1 - fillRate)
+                          else ceiling . logBase 2 $ rLBD ** surface * rNDD ** (1 - surface)
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -517,10 +517,11 @@ sortClauses s cm limit' = do
           then do setNth keys (2 * i) 0
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)               -- Second one... based on LBD
-                  r_ <- get' (rank c)
+--                  r_ <- get' (rank c)
+                  r_ <- get' (lits c)
                   r' <- nddOf s (lits c)
 --                  let r = 3 * r_
-                  let r = r' -- ceiling . sqrt . fromIntegral $ r_ * r'
+                  let r = ceiling . sqrt . fromIntegral $ r_ * r'
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -64,14 +64,13 @@ newLearntClause s@Solver{..} ps = do
            let lstack = lits c
                findMax :: Int -> Int -> Int -> IO Int -- Pick a second literal to watch:
                findMax ((<= k) -> False) j _ = return j
-               findMax i j val = do
-                 v <- lit2var <$> getNth lstack i
-                 a <- getNth assigns v
-                 b <- getNth level v
-                 if (a /= LBottom) && (val < b)
-                   then findMax (i + 1) i b
-                   else findMax (i + 1) j val
-           swapBetween lstack 2 =<< findMax 1 1 0 -- Let @max_i@ be the index of the literal with highest decision level
+               findMax i j val = do v <- lit2var <$> getNth lstack i
+                                    a <- getNth assigns v
+                                    b <- getNth level v
+                                    if (a /= LBottom) && (val < b)
+                                      then findMax (i + 1) i b
+                                      else findMax (i + 1) j val
+           swapBetween lstack 2 =<< findMax 1 1 0 -- get the index of the literal with highest level
            -- Bump, enqueue, store clause:
            claBumpActivity s c
            -- Add clause to all managers
@@ -84,7 +83,7 @@ newLearntClause s@Solver{..} ps = do
            unsafeEnqueue s l1 c
            -- Since unsafeEnqueue updates the 1st literal's level, setLBD should be called after unsafeEnqueue
            lbd <- lbdOf s (lits c)
-           set' (rank c) lbd
+           setRank c lbd
            -- assert (0 < rank c)
            -- set' (protected c) True
            return lbd
@@ -142,7 +141,7 @@ analyze s@Solver{..} confl = do
   dl <- decisionLevel s
   let loopOnClauseChain :: Clause -> Lit -> Int -> Int -> Int -> IO Int
       loopOnClauseChain c p ti bl pathC = do -- p : literal, ti = trail index, bl = backtrack level
-        d <- get' (rank c)
+        d <- getRank c
         when (0 /= d) $ claBumpActivity s c
         -- update LBD like #Glucose4.0
         when (2 < d) $ do
@@ -150,7 +149,7 @@ analyze s@Solver{..} confl = do
           when (nblevels + 1 < d) $ -- improve the LBD
             -- when (d <= 30) $ set' (protected c) True -- 30 is `lbLBDFrozenClause`
             -- seems to be interesting: keep it fro the next round
-            set' (rank c) nblevels    -- Update it
+            setRank c nblevels     --  Update it
         sc <- get' c
         let lstack = lits c
             loopOnLiterals :: Int -> Int -> Int -> IO (Int, Int)
@@ -169,7 +168,7 @@ analyze s@Solver{..} confl = do
                           -- UPDATEVARACTIVITY: glucose heuristics
                           r <- getNth reason v
                           when (r /= NullClause) $ do
-                            ra <- get' (rank r)
+                            ra <- getRank r
                             when (0 /= ra) $ pushTo an'lastDL q
                           -- end of glucose heuristics
                           loopOnLiterals (j + 1) b (pc + 1)
@@ -500,8 +499,8 @@ sortClauses s cm limit' = do
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
   updateNDD s
-  cl <- getEMA (emaCFast s)
-  surface <- if cl == 0 then return 0 else (/ cl) <$> getEMA (emaBFast s)  -- 0 <=backjumped level / coflict level < 1.0
+  cl <- getEMA (emaCDLvl s)
+  surface <- if cl == 0 then return 0 else (/ cl) <$> getEMA (emaBDLvl s)  -- 0 <=backjumped level / coflict level < 1.0
   let shiftLBD = activityWidth
       shiftIndex = shiftL 1 indexWidth
       am = fromIntegral activityMax :: Double
@@ -519,7 +518,7 @@ sortClauses s cm limit' = do
           then do setNth keys (2 * i) 0
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)               -- Second one... based on LBD
-                  rLBD <- fromIntegral <$> get' (rank c)       -- above the level
+                  rLBD <- fromIntegral <$> getRank c           -- above the level
                   rNDD <- fromIntegral <$> nddOf s (lits c)    -- under the level
                   let r = if rNDD == 1                         -- this implies rLBD == 1.
                           then 1

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -499,10 +499,8 @@ sortClauses s cm limit' = do
   keys <- newVec (2 * n) 0 :: IO (Vec Int)
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
-  updateNDD s
   rl <- get' (emaLSlow s)
   cl <- get' (emaRSlow s)
-  let iceburg = min 1 . max 0 $ rl / cl :: Double -- restart level / coflict level < 1.0
   let shiftLBD = activityWidth
       shiftIndex = shiftL 1 indexWidth
       am = fromIntegral activityMax :: Double
@@ -520,10 +518,7 @@ sortClauses s cm limit' = do
           then do setNth keys (2 * i) 0
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)               -- Second one... based on LBD
-                  rs <- fromIntegral <$> get' (rank c)       -- surface
-                  rv <- fromIntegral <$> nddOf s (lits c)    -- volume
-                  let r = ceiling . logBase 2 $ rs ** iceburg * rv ** (1 - iceburg) -- or rs * rv ** (1 - iceburg)
---                  let r = ceiling $ fromIntegral r_ * iceburg + fromIntegral r' * (1 - iceburg)
+                  r <- fromIntegral <$> get' (rank c)       -- surface
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -520,11 +520,10 @@ sortClauses s cm limit' = do
           then do setNth keys (2 * i) 0
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)               -- Second one... based on LBD
-                  r_ <- get' (rank c)
---                  r_ <- get' (lits c)
-                  r' <- nddOf s (lits c)
---                  let r = ceiling . sqrt . fromIntegral $ r_ * r'
-                  let r = ceiling $ fromIntegral r_ * iceburg + fromIntegral r' * (1 - iceburg)
+                  rs <- fromIntegral <$> get' (rank c)       -- surface
+                  rv <- fromIntegral <$> nddOf s (lits c)    -- volume
+                  let r = ceiling . logBase 2 $ rs ** iceburg * rv ** (1 - iceburg) -- or rs * rv ** (1 - iceburg)
+--                  let r = ceiling $ fromIntegral r_ * iceburg + fromIntegral r' * (1 - iceburg)
                   l <- locked s c
                   let d =if | l -> 0
                             | a < at -> rankMax

--- a/src/SAT/Mios/OptionParser.hs
+++ b/src/SAT/Mios/OptionParser.hs
@@ -32,7 +32,7 @@ data MiosProgramOption = MiosProgramOption
                      , _confRestartF          :: Double
                      , _confRestartS          :: Double
 --                     , _confRandomDecisionRate :: Int
-                     , _confMaxSize           :: Int
+                     , _confMaxClauses        :: Int
                      , _confCheckAnswer       :: Bool
                      , _confVerbose           :: Bool
                      , _confBenchmark         :: Integer
@@ -57,7 +57,7 @@ miosDefaultOption = MiosProgramOption
   , _confRestartF = restartExpansionF defaultConfiguration
   , _confRestartS = restartExpansionS defaultConfiguration
   --, _confRandomDecisionRate = randomDecisionRate defaultConfiguration
-  , _confMaxSize = 5000000    -- 5,000,000 = 5M
+  , _confMaxClauses = 16000000   -- 16,000,000 = 16M
   , _confCheckAnswer = False
   , _confVerbose = False
   , _confBenchmark = -1
@@ -92,7 +92,7 @@ miosOptions =
 --    (ReqArg (\v c -> c { _confRandomDecisionRate = read v }) (show (_confRandomDecisionRate miosDefaultOption)))
 --    "[solver] random selection rate (0 - 1000)"
   , Option [] ["maxsize"]
-    (ReqArg (\v c -> c { _confMaxSize = read v }) (show (_confMaxSize miosDefaultOption)))
+    (ReqArg (\v c -> c { _confMaxClauses = read v }) (show (_confMaxClauses miosDefaultOption)))
     "[solver] limit of the number of variables"
   , Option [':'] ["validate-assignment"]
     (NoArg (\c -> c { _validateAssignment = True }))

--- a/src/SAT/Mios/OptionParser.hs
+++ b/src/SAT/Mios/OptionParser.hs
@@ -93,7 +93,7 @@ miosOptions =
 --    "[solver] random selection rate (0 - 1000)"
   , Option [] ["maxsize"]
     (ReqArg (\v c -> c { _confMaxClauses = read v }) (show (_confMaxClauses miosDefaultOption)))
-    "[solver] limit of the number of variables"
+    "[solver] limit of the number of given clauses"
   , Option [':'] ["validate-assignment"]
     (NoArg (\c -> c { _validateAssignment = True }))
     "[solver] read an assignment from STDIN and validate it"

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -85,16 +85,15 @@ data Solver = Solver
               , stats      :: !(Vec [Int])       -- ^ statistics information holder
               , lbd'seen   :: !(Vec Int)         -- ^ used in lbd computation
               , lbd'key    :: !Int'              -- ^ used in lbd computation
-                -------- restart heuristics #62
-              , emaDFast    :: !Double'          -- ^ fast ema value of LBD
-              , emaDSlow    :: !Double'          -- ^ slow ema value of LBD
-              , emaAFast    :: !Double'          -- ^ fast ema value of assignment
-              , emaASlow    :: !Double'          -- ^ slow ema value of assignment
-              , emaRFast    :: !Double'          -- ^ fast ema value of decision level at conflict
-              , emaRSlow    :: !Double'          -- ^ slow ema value of decision level at conflict
-              , emaLFast    :: !Double'          -- ^ fast ema value of assignment
-              , emaLSlow    :: !Double'          -- ^ slow ema value of assignment
-              , emaScale    :: !Double'          -- ^ scaling factor
+                -------- restart heuristics #62, clause evaluation criteria #74
+              , emaAFast    :: !EMA              -- ^ Number of Assignments Fast
+              , emaASlow    :: !EMA              -- ^ Number of Assignments Slow
+              , emaBFast    :: !EMA              -- ^ Backjumped and Restart Dicision Level Fast
+              , emaBSlow    :: !EMA              -- ^ Backjumped and Restart Dicision Level Slow
+              , emaCFast    :: !EMA              -- ^ Conflicting Level Fast
+              , emaCSlow    :: !EMA              -- ^ Conflicting Level Slow
+              , emaDFast    :: !EMA              -- ^ (Literal Block) Distance Fast
+              , emaDSlow    :: !EMA              -- ^ (Literal Block) Distance Slow
               , nextRestart :: !Int'             -- ^ next restart in number of conflict
               }
 
@@ -141,16 +140,18 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     <*> newVec nv 0                        -- lbd'seen
     <*> new' 0                             -- lbd'key
     -- restart heuristics #62
-    <*> new' 0.0                           -- emaDFast
-    <*> new' 0.0                           -- emaDSlow
-    <*> new' 0.0                           -- emaAFast
-    <*> new' 0.0                           -- emaASlow
-    <*> new' 0.0                           -- emaRFast
-    <*> new' 0.0                           -- emaRSlow
-    <*> new' 0.0                           -- emaLFast
-    <*> new' 0.0                           -- emaLSlow
-    <*> new' 0.0                           -- emaScale
+    <*> fastEma                            -- emaAFast
+    <*> slowEma                            -- emaASlow
+    <*> fastEma                            -- emaBFast
+    <*> slowEma                            -- emaBSlow
+    <*> fastEma                            -- emaCFast
+    <*> slowEma                            -- emaCSlow
+    <*> fastEma                            -- emaDFast
+    <*> slowEma                            -- emaDSlow
     <*> new' 100                           -- nextRestart
+  where
+    fastEma = newEMA False . fst $ emaCoeffs conf
+    slowEma = newEMA True . snd $ emaCoeffs conf
 
 --------------------------------------------------------------------------------
 -- Accessors

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -59,7 +59,7 @@ data Solver = Solver
               , qHead      :: !Int'              -- ^ 'trail' is divided at qHead; assignment part and queue part
               , reason     :: !ClauseVector      -- ^ For each variable, the constraint that implied its value
               , level      :: !(Vec Int)         -- ^ For each variable, the decision level it was assigned
-              , ndl        :: !(Vec Int)         -- ^ For each variable, the number of dependent levels
+              , ndd        :: !(Vec Int)         -- ^ For each variable, the number of depending decisions
               , conflicts  :: !Stack             -- ^ Set of literals in the case of conflicts
                 -------- Variable Order
               , activities :: !(Vec Double)      -- ^ Heuristic measurement of the activity of a variable
@@ -114,7 +114,7 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     <*> new' 0                             -- qHead
     <*> newClauseVector (nv + 1)           -- reason
     <*> newVec nv (-1)                     -- level
-    <*> newVec nv 0                        -- ndl
+    <*> newVec (2 * nv) 0                  -- ndd
     <*> newStack nv                        -- conflicts
     -- Variable Order
     <*> newVec nv 0                        -- activities

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -114,7 +114,7 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     <*> new' 0                             -- qHead
     <*> newClauseVector (nv + 1)           -- reason
     <*> newVec nv (-1)                     -- level
-    <*> newVec (2 * nv) 0                  -- ndd
+    <*> newVec (2 * (nv + 1)) 0            -- ndd
     <*> newStack nv                        -- conflicts
     -- Variable Order
     <*> newVec nv 0                        -- activities

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -82,16 +82,14 @@ data Solver = Solver
               , an'lastDL  :: !Stack             -- ^ last decision level used in 'SAT.Mios.Main.analyze'
               , clsPool    :: ClausePool         -- ^ clause recycler
               , litsLearnt :: !Stack             -- ^ used in 'SAT.Mios.Main.analyze' and 'SAT.Mios.Main.search' to create a learnt clause
-              , stats      :: !(Vec [Int])       -- ^ statistics information holder
+              , stats      :: !(Vec Int)         -- ^ statistics information holder
               , lbd'seen   :: !(Vec Int)         -- ^ used in lbd computation
               , lbd'key    :: !Int'              -- ^ used in lbd computation
                 -------- restart heuristics #62, clause evaluation criteria #74
               , emaAFast    :: !EMA              -- ^ Number of Assignments Fast
               , emaASlow    :: !EMA              -- ^ Number of Assignments Slow
-              , emaBFast    :: !EMA              -- ^ Backjumped and Restart Dicision Level Fast
-              , emaBSlow    :: !EMA              -- ^ Backjumped and Restart Dicision Level Slow
-              , emaCFast    :: !EMA              -- ^ Conflicting Level Fast
-              , emaCSlow    :: !EMA              -- ^ Conflicting Level Slow
+              , emaBDLvl    :: !EMA              -- ^ Backjumped and Restart Dicision Level
+              , emaCDLvl    :: !EMA              -- ^ Conflicting Level
               , emaDFast    :: !EMA              -- ^ (Literal Block) Distance Fast
               , emaDSlow    :: !EMA              -- ^ (Literal Block) Distance Slow
               , nextRestart :: !Int'             -- ^ next restart in number of conflict
@@ -104,7 +102,7 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     -- Clause Database
     <$> newManager dummy_nc                -- clauses
     <*> newManager 2000                    -- learnts
-    <*> newWatcherList nv 2                -- watches
+    <*> newWatcherList nv 1                -- watches
     -- Assignment Management
     <*> newVec nv LBottom                  -- assigns
     <*> newVec nv LBottom                  -- phases
@@ -142,10 +140,8 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     -- restart heuristics #62
     <*> fastEma                            -- emaAFast
     <*> slowEma                            -- emaASlow
-    <*> fastEma                            -- emaBFast
-    <*> slowEma                            -- emaBSlow
-    <*> fastEma                            -- emaCFast
-    <*> slowEma                            -- emaCSlow
+    <*> newEMA True (2 ^ 10)               -- emaBDLvl
+    <*> newEMA True (2 ^ 10)               -- emaCDLvl
     <*> fastEma                            -- emaDFast
     <*> slowEma                            -- emaDSlow
     <*> new' 100                           -- nextRestart

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -59,6 +59,7 @@ data Solver = Solver
               , qHead      :: !Int'              -- ^ 'trail' is divided at qHead; assignment part and queue part
               , reason     :: !ClauseVector      -- ^ For each variable, the constraint that implied its value
               , level      :: !(Vec Int)         -- ^ For each variable, the decision level it was assigned
+              , ndl        :: !(Vec Int)         -- ^ For each variable, the number of dependent levels
               , conflicts  :: !Stack             -- ^ Set of literals in the case of conflicts
                 -------- Variable Order
               , activities :: !(Vec Double)      -- ^ Heuristic measurement of the activity of a variable
@@ -113,6 +114,7 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     <*> new' 0                             -- qHead
     <*> newClauseVector (nv + 1)           -- reason
     <*> newVec nv (-1)                     -- level
+    <*> newVec nv 0                        -- ndl
     <*> newStack nv                        -- conflicts
     -- Variable Order
     <*> newVec nv 0                        -- activities

--- a/src/SAT/Mios/Types.hs
+++ b/src/SAT/Mios/Types.hs
@@ -321,7 +321,7 @@ data MiosConfiguration = MiosConfiguration
                          , emaCoeffs          :: !(Int, Int) -- ^ the coefficients for restarts
                          , restartExpansionB  :: !Double     -- ^ Blocking restart expansion factor
                          , restartExpansionF  :: !Double     -- ^ Forcing restart expansion factor
-                         , restartExpansionS  :: !Double     -- ^ static Steps betwen restarts
+                         , restartExpansionS  :: !Double     -- ^ static Steps between restarts
                          }
   deriving (Eq, Ord, Read, Show)
 
@@ -333,7 +333,7 @@ data MiosConfiguration = MiosConfiguration
 -- * Mios-1.2     uses @(0.95, 0.999, 0)@.
 --
 defaultConfiguration :: MiosConfiguration
-defaultConfiguration = MiosConfiguration 0.95 0.999 0 (ef, es) 1.19 1.01 100
+defaultConfiguration = MiosConfiguration 0.95 0.999 0 (ef, es) 1.20 1.01 100
   where ef = (2 :: Int) ^ ( 5 :: Int)
         es = (2 :: Int) ^ (14 :: Int)
 

--- a/src/SAT/Mios/Types.hs
+++ b/src/SAT/Mios/Types.hs
@@ -333,7 +333,7 @@ data MiosConfiguration = MiosConfiguration
 -- * Mios-1.2     uses @(0.95, 0.999, 0)@.
 --
 defaultConfiguration :: MiosConfiguration
-defaultConfiguration = MiosConfiguration 0.95 0.999 0 (ef, es) 1.20 1.05 100
+defaultConfiguration = MiosConfiguration 0.95 0.999 0 (ef, es) 1.19 1.01 100
   where ef = (2 :: Int) ^ ( 5 :: Int)
         es = (2 :: Int) ^ (14 :: Int)
 

--- a/src/SAT/Mios/Vec.hs
+++ b/src/SAT/Mios/Vec.hs
@@ -98,6 +98,7 @@ instance VecFamily (UVector Int) Int where
   growBy = UV.unsafeGrow
   asList v = mapM (UV.unsafeRead v) [0 .. UV.length v - 1]
 
+{-
 -- Note: type @[Int]@ is selected for 'UVector' not to export it.
 data instance Vec [Int] = Vec (UVector Int)
 
@@ -119,6 +120,7 @@ instance VecFamily (Vec [Int]) Int where
   {-# SPECIALIZE INLINE growBy :: Vec [Int] -> Int -> IO (Vec [Int]) #-}
   growBy (Vec v) n = Vec <$> UV.unsafeGrow v n
   asList (Vec v) = mapM (getNth v) [0 .. UV.length v - 1]
+-}
 
 {- NOT IN USE
 data instance Vec [Double] = Vec (UVector Double)
@@ -185,6 +187,9 @@ instance VecFamily ByteArrayInt Int where
                   BA.writeByteArray v 0 (0 :: Int)
                   BA.setByteArray v 1 n k
                   return $ ByteArrayInt v
+  growBy (ByteArrayInt v) n = do v' <- BA.newByteArray (BA.sizeofMutableByteArray v + 8 * n)
+                                 BA.copyMutableByteArray v' 0 v 0 (BA.sizeofMutableByteArray v)
+                                 return (ByteArrayInt v')
   asList (ByteArrayInt v) = mapM (BA.readByteArray v) [0 .. div (BA.sizeofMutableByteArray v) 8 - 1]
 
 instance VecFamily ByteArrayDouble Double where

--- a/utils/mkEvo.R
+++ b/utils/mkEvo.R
@@ -41,19 +41,25 @@ getData = function (single, t, p) {
     df <- rbind(df, data.frame(id=paste("assign ratio", tag), num=index,
                                value=d[["emaAFast"]]/d[["emaASlow"]], type="assign ratio"))
     df <- rbind(df, data.frame(id=paste("FAST", tag), num=index,
-                               value=d[["emaLFast"]], type="backjump level"))
+                               value=d[["emaBFast"]], type="backed level"))
     df <- rbind(df, data.frame(id=paste("SLOW", tag), num=index,
-                               value=d[["emaLSlow"]], type="backjump level"))
+                               value=d[["emaBSlow"]], type="backed level"))
     df <- rbind(df, data.frame(id=paste("level ratio", tag), num=index,
-                               value=d[["emaLFast"]]/d[["emaLSlow"]], type="blevel ratio"))
+                               value=d[["emaBFast"]]/d[["emaBSlow"]], type="blevel ratio"))
     df <- rbind(df, data.frame(id=paste("FAST", tag), num=index,
-                               value=d[["emaRFast"]], type="conflict level"))
+                               value=d[["emaCFast"]], type="conflict level"))
     df <- rbind(df, data.frame(id=paste("SLOW", tag), num=index,
-                               value=d[["emaRSlow"]], type="conflict level"))
+                               value=d[["emaCSlow"]], type="conflict level"))
     df <- rbind(df, data.frame(id=paste("level ratio", tag), num=index,
-                               value=d[["emaRFast"]]/d[["emaRSlow"]], type="clevel ratio"))
+                               value=d[["emaCFast"]]/d[["emaCSlow"]], type="clevel ratio"))
     df <- rbind(df, data.frame(id=paste("b/c ratio", tag), num=index,
-                               value=d[["emaRSlow"]]/d[["emaLSlow"]], type="b/c ratio"))
+                               value=d[["emaBSlow"]]/d[["emaCSlow"]], type="b/c ratio"))
+
+    df <- rbind(df, data.frame(id=paste("backed", tag), num=index,
+                               value=d[["emaBSlow"]], type="levels"))
+    df <- rbind(df, data.frame(id=paste("conflicting", tag), num=index,
+                               value=d[["emaCSlow"]], type="levels"))
+
     df
     }
 
@@ -124,14 +130,15 @@ graph = function (df, kind, mes, logGraph=FALSE, leg=FALSE, hls=NULL, vls=NULL) 
 
     df[["id"]] = gsub("=.+", "", df[["id"]])
     g2 <- graph(df, "assigns",        "EMA of the assigned vars for blocking restart", TRUE, FALSE, ew)
-    g3 <- graph(df, "assign ratio",   "", TRUE, FALSE, NULL, blockTh)
+    g3 <- graph(df, "assign ratio",   "assign fast / slow ratio", TRUE, FALSE, NULL, blockTh)
     g4 <- graph(df, "distances",      "EMA of Literal Block Distance for forcing restart", TRUE, FALSE, ew)
-    g5 <- graph(df, "distance ratio", "", TRUE, FALSE, NULL, forceTh)
-    g6 <- graph(df, "conflict level", "EMA of Decision Level of conflict", TRUE, FALSE, ew)
-    g7 <- graph(df, "clevel ratio",   "", TRUE, FALSE)
-    g8 <- graph(df, "backjump level", "EMA of Decision Level by BackJump", TRUE, FALSE, ew)
+    g5 <- graph(df, "distance ratio", "distance fast / slow ratio", TRUE, FALSE, NULL, forceTh)
+    g6 <- graph(df, "conflict level", "EMA of Decision Level of Conflict", TRUE, FALSE, NULL)
+#    g7 <- graph(df, "clevel ratio",   "conflict level fast / slow ratio", TRUE, FALSE)
+    g7 <- graph(df, "levels",   "EMA of conflicting and backed levels", TRUE, FALSE)
+    g8 <- graph(df, "backed level", "EMA of Decision Level by BackJump", TRUE, FALSE, NULL)
     # g9 <- graph(df, "blevel ratio",   "", TRUE)
-    g9 <- graph(df, "b/c ratio",   "", TRUE, FALSE)
+    g9 <- graph(df, "b/c ratio",   "backed level / conflict level (fill ratio)", TRUE, FALSE)
     grid.newpage()
     pushViewport(viewport(layout=grid.layout(5,2),width=0.94,height=0.94))
     print(g1, vp=viewport(layout.pos.row=1, layout.pos.col=c(1,2)))


### PR DESCRIPTION
- introduce a new clause criterion: NDD #76 
- use average decision level #76 
- use `Vec Int` instead of `Vec [Int]` for keyVector in ClauseManager #77 
- reduce the expansion factor for growable vectors #77 
- `newWatcherList` ditched `M.replicate` #77 
- set the initial size of watcher list to 1 instead of 8 #77 
- implement `growBy` for `Vec Int` #77 
- use `ByteString.uncons` instead of a pair of `head` and `tail` #78
- reimplement a literal checker in `causeNew` #78 
- stop checking polarity of literals during clause injection #78 
- absorb `rank` into `lits` to reduce the number of object allocation #78 
- use gitrev for help message #78




```
$ sat-benchmark -3 250 -L 225 -s mios-74 mios-74-ema mios-74-lbd mios-74-horizon mios-74-horizon-opt mios-74-altitude
solver, num, target, time
# sat-benchmark 0.14.1, j=1, t=510, p='' on xingu @ 2018-02-26T11:23:58+09:00
# 2018-02-11T00:21 mios-74; # mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios
"mios-74", 1, 225,       54.74
"mios-74", 2, 250,       145.21
"mios-74", 3, "itox",    24.16
"mios-74", 4, "m283",    81.88
"mios-74", 5, "38b",     33.93
"mios-74", 6, "44b",     212.68
# 2018-02-10T00:27 mios-74-ema; # mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios
"mios-74-ema", 1, 225,   66.29
"mios-74-ema", 2, 250,   167.50
"mios-74-ema", 3, "itox",        24.17
"mios-74-ema", 4, "m283",        90.35
"mios-74-ema", 5, "38b",         21.16
"mios-74-ema", 6, "44b",         505.53
# 2018-02-09T16:38 mios-74-lbd; # mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios
"mios-74-lbd", 1, 225,   68.70
"mios-74-lbd", 2, 250,   166.85
"mios-74-lbd", 3, "itox",        23.04
"mios-74-lbd", 4, "m283",        92.38
"mios-74-lbd", 5, "38b",         20.78
"mios-74-lbd", 6, "44b",         507.36
# 2018-02-15T18:56 mios-74-horizon; # mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios
"mios-74-horizon", 1, 225,       65.03
"mios-74-horizon", 2, 250,       176.38
"mios-74-horizon", 3, "itox",    24.67
"mios-74-horizon", 4, "m283",    95.67
"mios-74-horizon", 5, "38b",     11.80
"mios-74-horizon", 6, "44b",     92.98
# 2018-02-12T14:31 mios-74-horizon-opt; # mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios
"mios-74-horizon-opt", 1, 225,   58.97
"mios-74-horizon-opt", 2, 250,   166.18
"mios-74-horizon-opt", 3, "itox",        21.24
"mios-74-horizon-opt", 4, "m283",        124.50
"mios-74-horizon-opt", 5, "38b",         191.12
"mios-74-horizon-opt", 6, "44b",         506.42
# 2018-02-25T14:44 mios-74-altitude; # mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios
"mios-74-altitude", 1, 225,      66.11
"mios-74-altitude", 2, 250,      174.27
"mios-74-altitude", 3, "itox",   22.68
"mios-74-altitude", 4, "m283",   7.43
"mios-74-altitude", 5, "38b",    40.74
"mios-74-altitude", 6, "44b",    33.81
```