### PR TITLE
revising memory management

### DIFF
--- a/app/mios.hs
+++ b/app/mios.hs
@@ -13,15 +13,15 @@ import SAT.Mios
 import Development.GitRev
 
 gitId :: String
-gitId = " (" ++ take 8 $(gitHash) ++ "@" ++ $(gitBranch) ++ ")"
+gitId = versionId ++ "/commit/" ++ $(gitHash)
 
 usage :: String
-usage = miosUsage $ versionId ++ gitId ++ "\nUsage: mios [OPTIONS] target.cnf"
+usage = miosUsage $ gitId ++ "\nUsage: mios [OPTIONS] target.cnf"
 
 -- | main
 main :: IO ()
 main = do opts <- miosParseOptionsFromArgs versionId
-          if | _displayVersion opts        -> putStrLn (versionId ++ gitId)
+          if | _displayVersion opts        -> putStrLn gitId
              | _displayHelp opts           -> putStrLn usage
              | _targetFile opts == Nothing -> putStrLn usage
              | _validateAssignment opts    -> executeValidator opts

--- a/app/mios.hs
+++ b/app/mios.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-   MultiWayIf
+    MultiWayIf
+  , TemplateHaskell
   #-}
 -- | Executable of 'Minisat Implementation and Optimization Study'
 module Main
@@ -9,14 +10,18 @@ module Main
        where
 
 import SAT.Mios
+import Development.GitRev
+
+gitId :: String
+gitId = " (" ++ take 8 $(gitHash) ++ "@" ++ $(gitBranch) ++ ")"
 
 usage :: String
-usage = miosUsage $ versionId ++ "\nUsage: mios [OPTIONS] target.cnf"
+usage = miosUsage $ versionId ++ gitId ++ "\nUsage: mios [OPTIONS] target.cnf"
 
 -- | main
 main :: IO ()
 main = do opts <- miosParseOptionsFromArgs versionId
-          if | _displayVersion opts        -> putStrLn versionId
+          if | _displayVersion opts        -> putStrLn (versionId ++ gitId)
              | _displayHelp opts           -> putStrLn usage
              | _targetFile opts == Nothing -> putStrLn usage
              | _validateAssignment opts    -> executeValidator opts

--- a/package.yaml
+++ b/package.yaml
@@ -54,6 +54,7 @@ executables:
       - condition: flag(llvm)
         then:
           ghc-prof-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -fprof-auto -rtsopts
+                                --with-rtsopts="-A64M -c -H128M -M8G"
         else:
           ghc-prof-options:	-O2 -funbox-strict-fields -fprof-auto -rtsopts
   cnf-stat:

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-74-altitude-no-read:
+  mios-77:
     source-dirs:     app
     main:            mios.hs
     dependencies:    mios

--- a/package.yaml
+++ b/package.yaml
@@ -41,21 +41,33 @@ dependencies:
   - primitive >=0.6
   - bytestring >=0.10
   - vector >=0.12
-
 library:
   source-dirs:       src
 
 executables:
-  mios-77:
+  mios-78:
     source-dirs:     app
     main:            mios.hs
-    dependencies:    mios
+    dependencies:
+      - mios
+      - gitrev
     when:
       - condition: flag(llvm)
         then:
           ghc-prof-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -fprof-auto -rtsopts
+                                --rtsopts-with="-H16M -A16M"
         else:
           ghc-prof-options:	-O2 -funbox-strict-fields -fprof-auto -rtsopts
+  cnf-stat:
+    source-dirs:     utils
+    main:            cnf-stat.hs
+    dependencies:    mios
+    when:
+      - condition:   flag(utils)
+        then:
+          buildable: true
+        else:
+          buildable: false
   cnf-stat:
     source-dirs:     utils
     main:            cnf-stat.hs

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-78:
+  mios-77:
     source-dirs:     app
     main:            mios.hs
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-74-altitude:
+  mios-74-altitude-no-read:
     source-dirs:     app
     main:            mios.hs
     dependencies:    mios

--- a/package.yaml
+++ b/package.yaml
@@ -54,7 +54,6 @@ executables:
       - condition: flag(llvm)
         then:
           ghc-prof-options:	-O2 -funbox-strict-fields -fllvm -optlo-O3 -fprof-auto -rtsopts
-                                --with-rtsopts="-A64M -c -H128M -M8G"
         else:
           ghc-prof-options:	-O2 -funbox-strict-fields -fprof-auto -rtsopts
   cnf-stat:

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -76,7 +76,7 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
   (desc, cls) <- parseCNF (_targetFile opts)
   -- when (_numberOfVariables desc == 0) $ error $ "couldn't load " ++ show cnfFile
   solverId <- myThreadId
-  when (_confMaxSize opts < _numberOfVariables desc || 10000000 < _numberOfClauses desc) $
+  when (_confMaxClauses opts < _numberOfClauses desc) $
     if -1 == _confBenchmark opts
       then errorWithoutStackTrace $ "ABORT: too many variables or clauses to solve, " ++ show desc
       else reportResult opts 0 (Left OutOfMemory) >> killThread solverId
@@ -94,7 +94,7 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
                          threadDelay $ fromMicro * fromIntegral (_confBenchmark opts)
                          putMVar token (Left TimeOut)
                          killThread solverId
-    when (_confMaxSize opts < _numberOfVariables desc) $
+    when (_confMaxClauses opts < _numberOfClauses desc) $
       if -1 == _confBenchmark opts
         then errorWithoutStackTrace $ "ABORT: too many variables to solve, " ++ show desc
         else putMVar token (Left OutOfMemory) >> killThread solverId

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -90,7 +90,7 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
                          threadDelay $ fromMicro * fromIntegral (_confBenchmark opts)
                          putMVar token (Left TimeOut)
                          killThread solverId
-    when (False && _confMaxSize opts < _numberOfVariables desc) $
+    when (_confMaxSize opts < _numberOfVariables desc) $
       if -1 == _confBenchmark opts
         then errorWithoutStackTrace $ "ABORT: too many variables to solve, " ++ show desc
         else putMVar token (Left OutOfMemory) >> killThread solverId

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "mios-1.6.1WIP#72#73#74 -- https://github.com/shnarazk/mios"
+versionId = "mios-1.6.1WIP#72#73#74#77 -- https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -41,6 +41,8 @@ import Control.Monad ((<=<), unless, void, when)
 import Data.Char
 import qualified Data.ByteString.Char8 as B
 import Numeric (showFFloat)
+-- import Streamly
+-- import qualified Streamly.Prelude as S
 import System.CPUTime
 import System.Exit
 import System.IO
@@ -50,9 +52,13 @@ import SAT.Mios.Main
 import SAT.Mios.OptionParser
 import SAT.Mios.Validator
 
+-- import SAT.Mios.Solver (clauses)
+-- import SAT.Mios.Clause (Clause(..))
+-- import SAT.Mios.ClauseManager (getClauseVector)
+
 -- | version name
 versionId :: String
-versionId = "mios-1.6.1WIP#72#73#74#77 -- https://github.com/shnarazk/mios"
+versionId = "mios-1.6.1WIP#72#73#74#77#78 -- https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0
@@ -73,18 +79,52 @@ executeSolverOn path = executeSolver (miosDefaultOption { _targetFile = Just pat
 -- This is another entry point for standalone programs.
 executeSolver :: MiosProgramOption -> IO ()
 executeSolver opts@(_targetFile -> (Just cnfFile)) = do
+  solverId <- myThreadId
   (desc, cls) <- parseCNF (_targetFile opts)
   -- when (_numberOfVariables desc == 0) $ error $ "couldn't load " ++ show cnfFile
-  solverId <- myThreadId
   when (_confMaxClauses opts < _numberOfClauses desc) $
     if -1 == _confBenchmark opts
-      then errorWithoutStackTrace $ "ABORT: too many variables or clauses to solve, " ++ show desc
+      then errorWithoutStackTrace $ "ABORT: too many clauses to solve, " ++ show desc
       else reportResult opts 0 (Left OutOfMemory) >> killThread solverId
-  s <- newSolver (toMiosConf opts) desc
-  injectClausesFromCNF s desc cls
+{-
   t0 <- reportElapsedTime False "" $ if _confVerbose opts || 0 <= _confBenchmark opts then -1 else 0
-  void $ reportElapsedTime (_confVerbose opts) ("## [" ++ showPath cnfFile ++ "] Parse: ") t0
+  putStrLn $ " - number of clauses = " ++ show (_numberOfClauses desc)
+
+  -- original ByteString
+  s <- newSolver (toMiosConf opts) desc
+  ct <- reportElapsedTime True " - making a new solver: " t0
+  injectClausesFromCNF s desc . snd =<< parseCNF (_targetFile opts)
+  ct <- reportElapsedTime True "injecting w/ ByteString: " ct
+
+--  -- Streamly
+--  s' <- newSolver (toMiosConf opts) desc
+--  ct <- reportElapsedTime False " - making a new solver: " ct
+--  injectClausesStreamly s' desc cls
+--  ct <- reportElapsedTime True "injecting w/ streamly: " ct
+
+--  -- Handle-based ByteString
+--  s' <- newSolver (toMiosConf opts) desc
+--  ct <- reportElapsedTime False "- making a new solver: " ct
+--  (desc', h') <- parseCNFHeader (_targetFile opts)
+--  injectClausesFromHandle s' desc' h'
+--  ct <- reportElapsedTime True "injecting w/ Handle: " ct
+
+  -- memory-to-memory pseudo generator
+  s' <- newSolver (toMiosConf opts) desc
+  ct <- reportElapsedTime False " - making a new solver: " ct
+  realNc <- get' (clauses s)
+  cvec <- getClauseVector (clauses s)
+  let loop :: Int -> IO Int
+      loop n@((< realNc) -> False) = return n
+      loop i = do c <- getNth cvec i
+                  unless (c == NullClause) $ void $ addClause s' (lits c)
+                  loop (i + 1)
+  realc <- loop 1
+  void $ reportElapsedTime True ("injecting w/o IO (" ++ show realc ++ "):") ct
+  killThread solverId
+-}
   token <- newEmptyMVar --  :: IO (MVar (Maybe Solver))
+  t0 <- reportElapsedTime False "" $ if _confVerbose opts || 0 <= _confBenchmark opts then -1 else 0
   handle (\case
              UserInterrupt -> putStrLn "User interrupt recieved."
              ThreadKilled  -> reportResult opts t0 =<< readMVar token
@@ -94,10 +134,11 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
                          threadDelay $ fromMicro * fromIntegral (_confBenchmark opts)
                          putMVar token (Left TimeOut)
                          killThread solverId
-    when (_confMaxClauses opts < _numberOfClauses desc) $
-      if -1 == _confBenchmark opts
-        then errorWithoutStackTrace $ "ABORT: too many variables to solve, " ++ show desc
-        else putMVar token (Left OutOfMemory) >> killThread solverId
+    s <- newSolver (toMiosConf opts) desc
+    -- ct <- reportElapsedTime True "- making a new solver: " t0
+    injectClausesFromCNF s desc cls
+    void $ reportElapsedTime (_confVerbose opts) ("## [" ++ showPath cnfFile ++ "] Parse: ") t0
+    -- ct <- reportElapsedTime True "injecting w/ ByteString: " ct
     when (0 < _confDumpStat opts) $ dumpStats DumpCSVHeader s
     result <- solve s []
     putMVar token result
@@ -129,7 +170,7 @@ reportResult opts@(_targetFile -> Just cnfFile) t0 (Right result) = do
     UNSAT t -> do when (_confVerbose opts) $ hPutStrLn stderr "UNSAT" -- contradiction
                   print t
   dumpAssigmentAsCNF (_outputFile opts) result
-  valid <- if _confCheckAnswer opts || 0 <= _confBenchmark opts
+  valid <- if _confCheckAnswer opts -- || 0 <= _confBenchmark opts
            then case result of
                   SAT asg -> do (desc, cls) <- parseCNF (_targetFile opts)
                                 s' <- newSolver (toMiosConf opts) desc
@@ -245,6 +286,13 @@ dumpAssigmentAsCNF (Just fname) (UNSAT _) =
 dumpAssigmentAsCNF (Just fname) (SAT l) =
   withFile fname WriteMode $ \h -> do hPutStrLn h "s SAT"; hPutStrLn h . (++ " 0") . unwords $ map show l
 
+showPath :: FilePath -> String
+showPath str = replicate (len - length basename) ' ' ++ if elem '/' str then basename else basename'
+  where
+    len = 50
+    basename = reverse . takeWhile (/= '/') . reverse $ str
+    basename' = take len str
+
 --------------------------------------------------------------------------------
 -- DIMACS CNF Reader
 --------------------------------------------------------------------------------
@@ -257,18 +305,19 @@ parseCNF target@(Just cnfFile) = do
                       (x, second) -> case B.readInt (skipWhitespace second) of
                                        Just (y, _) -> CNFDescription x y target
       seek :: B.ByteString -> IO (CNFDescription, B.ByteString)
-      seek bs
+      seek !bs
         | B.head bs == 'p' = return (parseP l, B.tail bs')
         | otherwise = seek (B.tail bs')
         where (l, bs') = B.span ('\n' /=) bs
   seek =<< B.readFile cnfFile
 
 -- | parses ByteString then injects the clauses in it into a solver
+{-# INLINABLE injectClausesFromCNF #-}
 injectClausesFromCNF :: Solver -> CNFDescription -> B.ByteString -> IO ()
 injectClausesFromCNF s (CNFDescription nv nc _) bs = do
   let maxLit = int2lit $ negate nv
-  buffer <- newVec (maxLit + 1) 0
-  polvec <- newVec (maxLit + 1) 0
+  buffer <- newVec (maxLit + 1) 0 :: IO (Vec Int)
+  polvec <- newVec (maxLit + 1) 0 :: IO (Vec Int)
   let loop :: Int -> B.ByteString -> IO ()
       loop ((< nc) -> False) _ = return ()
       loop !i !b = loop (i + 1) =<< readClause s buffer polvec b
@@ -299,41 +348,117 @@ skipComments !s
   where
     c = B.head s
 
-{-# INLINABLE parseInt #-}
+{-# INLINE parseInt #-}
 parseInt :: B.ByteString -> (Int, B.ByteString)
 parseInt !st = do
   let !zero = ord '0'
       loop :: B.ByteString -> Int -> (Int, B.ByteString)
-      loop !s !val = case B.head s of
-        c | '0' <= c && c <= '9'  -> loop (B.tail s) (val * 10 + ord c - zero)
-        _ -> (val, B.tail s)
-  case B.head st of
-    '-' -> let (k, x) = loop (B.tail st) 0 in (negate k, x)
-    '0' -> (0, B.tail st)
---    '+' -> loop st (0 :: Int)
-    _   -> loop st 0
---    c | '0' <= c && c <= '9'  -> loop st 0
---    _ -> error "PARSE ERROR! Unexpected char"
+      loop !s !val = case B.uncons s of
+        Just (c, s') -> if '0' <= c && c <= '9' then loop s' (val * 10 + ord c - zero) else (val, s')
+  case B.uncons st of
+    Just ('-', st') -> let (k, x) = loop st' 0 in (negate k, x)
+    Just ('0', st') -> (0, st')
+    _ -> loop st 0
 
-{-# INLINABLE readClause #-}
+{-# INLINE readClause #-}
 readClause :: Solver -> Stack -> Vec Int -> B.ByteString -> IO B.ByteString
 readClause s buffer bvec stream = do
-  let
-    loop :: Int -> B.ByteString -> IO B.ByteString
-    loop !i !b = case parseInt $ skipWhitespace b of
-                   (0, b') -> do setNth buffer 0 $ i - 1
-                                 sortStack buffer
-                                 void $ addClause s buffer
-                                 return b'
-                   (k, b') -> case int2lit k of
-                                l -> do setNth buffer i l
-                                        setNth bvec l LiftedT
-                                        loop (i + 1) b'
+  let loop :: Int -> B.ByteString -> IO B.ByteString
+      loop !i !b = case parseInt $ skipWhitespace b of
+                     (0, b') -> do setNth buffer 0 $ i - 1
+                                   void $ addClause s buffer
+                                   return b'
+                     (k, b') -> case int2lit k of
+                                  l -> do setNth buffer i l
+                                          setNth bvec l LiftedT
+                                          loop (i + 1) b'
   loop 1 . skipComments . skipWhitespace $ stream
 
-showPath :: FilePath -> String
-showPath str = replicate (len - length basename) ' ' ++ if elem '/' str then basename else basename'
-  where
-    len = 50
-    basename = reverse . takeWhile (/= '/') . reverse $ str
-    basename' = take len str
+{-
+-------------------------------------------------------------------------------- Streamly
+
+parseCNFHeader :: Maybe FilePath -> IO (CNFDescription, Handle)
+parseCNFHeader target@(Just cnfFile) = do
+  h <- openFile cnfFile ReadMode
+  liftIO $ hSetBuffering h LineBuffering
+  let skip = do s <- B.hGetLine h
+                if B.empty == s
+                  then return (CNFDescription (-1) (-1) target, undefined)
+                  else case B.head s of
+                         'c'-> skip
+                         'p' -> let [_, cnf, nv', nc'] = B.words s
+                                    Just (nv, _) = B.readInt nv'
+                                    Just (nc, _) = B.readInt nc'
+                                in return (CNFDescription nv nc target, h)
+                         otherwise -> putStrLn (B.unpack s) >> skip
+  skip
+
+-- | parses ByteString then injects the clauses in it into a solver
+{-# INLINABLE injectClausesStreamly #-}
+injectClausesStreamly :: Solver -> CNFDescription -> Handle -> IO ()
+injectClausesStreamly s (CNFDescription nv nc _) h = do
+  let maxLit = int2lit $ negate nv
+  buffer <- newVec (maxLit + 1) 0 :: IO (Vec Int)
+  polvec <- newVec (maxLit + 1) 0 :: IO (Vec Int)
+  let readClause' :: [Lit] -> IO ()
+      readClause' lits = do
+        let loop :: [Lit] -> Int -> IO ()
+            loop [] i = do setNth buffer 0 (i - 1) -- '1` is the literal corresponding to '0'
+                           void $ addClause s buffer
+            loop (l:ls) i = do setNth buffer i l
+                               setNth polvec l LiftedT
+                               loop ls (i + 1)
+        loop lits 1
+  runStreaming $ serially $ do y <- S.fromHandle h
+                               let lits = map (int2lit . read) (words y)
+                               liftIO $ unless (null lits) $ readClause' (init lits)
+  -- static polarity
+  let checkPolarity :: Int -> IO ()
+      checkPolarity ((< nv) -> False) = return ()
+      checkPolarity v = do
+        p <- getNth polvec $ var2lit v True
+        if p == LiftedF
+          then setAssign s v p
+          else do n <- getNth polvec $ var2lit v False
+                  when (n == LiftedF) $ setAssign s v p
+        checkPolarity $ v + 1
+  checkPolarity 1
+
+---------------------------------------------------------------------- Handle-based ByteString
+
+-- | parses ByteString then injects the clauses in it into a solver
+{-# INLINABLE injectClausesFromHandle #-}
+injectClausesFromHandle :: Solver -> CNFDescription -> Handle -> IO ()
+injectClausesFromHandle s (CNFDescription nv nc _) h = do
+  let maxLit = int2lit $ negate nv
+  buffer <- newVec (maxLit + 1) 0 :: IO (Vec Int)
+  polvec <- newVec (maxLit + 1) 0 :: IO (Vec Int)
+  let loop :: Int -> IO ()
+      loop ((< nc) -> False) = return ()
+      loop !i = readClauseFromHandle s buffer polvec h >> loop (i + 1)
+  loop 0
+  -- static polarity
+  let checkPolarity :: Int -> IO ()
+      checkPolarity ((< nv) -> False) = return ()
+      checkPolarity v = do
+        p <- getNth polvec $ var2lit v True
+        if p == LiftedF
+          then setAssign s v p
+          else do n <- getNth polvec $ var2lit v False
+                  when (n == LiftedF) $ setAssign s v p
+        checkPolarity $ v + 1
+  checkPolarity 1
+
+{-# INLINE readClauseFromHandle #-}
+readClauseFromHandle :: Solver -> Stack -> Vec Int -> Handle -> IO ()
+readClauseFromHandle s buffer bvec h = do
+  let loop :: Int -> B.ByteString -> IO ()
+      loop !i !b = case parseInt $ skipWhitespace b of
+                     (0, _) -> do setNth buffer 0 $ i - 1
+                                  void $ addClause s buffer
+                     (k, b') -> case int2lit k of
+                                  l -> do setNth buffer i l
+                                          setNth bvec l LiftedT
+                                          loop (i + 1) b'
+  loop 1 . skipComments . skipWhitespace =<< B.hGetLine h
+-}

--- a/src/SAT/Mios/Clause.hs
+++ b/src/SAT/Mios/Clause.hs
@@ -13,6 +13,8 @@ module SAT.Mios.Clause
        (
          Clause (..)
        , newClauseFromStack
+       , getRank
+       , setRank
          -- * Vector of Clause
        , ClauseVector
        , newClauseVector
@@ -30,10 +32,10 @@ import SAT.Mios.Types
 -- This matches both of @Clause@ and @GClause@ in MiniSat.
 data Clause = Clause
               {
-                rank       :: !Int'     -- ^ goodness like LBD; computed in 'Ranking'
-              , activity   :: !Double'  -- ^ activity of this clause
---              , protected  :: !Bool'    -- ^ protected from reduce
+               activity   :: !Double'  -- ^ activity of this clause
               , lits       :: !Stack    -- ^ which this clause consists of
+--            , protected  :: !Bool'    -- ^ protected from reduce
+--            , rank       :: !Int'     -- ^ goodness like LBD; computed in 'Ranking'
               }
   | NullClause                              -- as null pointer
 --  | BinaryClause Lit                        -- binary clause consists of only a propagating literal
@@ -93,12 +95,20 @@ instance StackFamily Clause Lit where
 newClauseFromStack :: Bool -> Stack -> IO Clause
 newClauseFromStack l vec = do
   n <- get' vec
-  v <- newStack n
+  v <- newStack (n + 1)
   let
-    loop ((<= n) -> False) = return ()
+    loop ((<= n) -> False) = setNth vec (n + 1) (if l then 1 else 0)
     loop i = (setNth v i =<< getNth vec i) >> loop (i + 1)
   loop 0
-  Clause <$> new' (if l then 1 else 0) <*> new' 0.0 {- <*> new' False -} <*> return v
+  Clause <$> new' 0.0 {- <*> new' False -} <*> return v
+
+{-# INLINE getRank #-}
+getRank :: Clause -> IO Int
+getRank Clause{..} = do n <- get' lits; getNth lits (n + 1)
+
+{-# INLINE setRank #-}
+setRank :: Clause -> Int -> IO ()
+setRank Clause{..} k = do n <- get' lits; setNth lits (n + 1) k
 
 -------------------------------------------------------------------------------- Clause Vector
 

--- a/src/SAT/Mios/Clause.hs
+++ b/src/SAT/Mios/Clause.hs
@@ -33,9 +33,8 @@ import SAT.Mios.Types
 data Clause = Clause
               {
                activity   :: !Double'  -- ^ activity of this clause
-              , lits       :: !Stack    -- ^ which this clause consists of
+              , lits       :: !Stack    -- ^ literals and rank
 --            , protected  :: !Bool'    -- ^ protected from reduce
---            , rank       :: !Int'     -- ^ goodness like LBD; computed in 'Ranking'
               }
   | NullClause                              -- as null pointer
 --  | BinaryClause Lit                        -- binary clause consists of only a propagating literal

--- a/src/SAT/Mios/Clause.hs
+++ b/src/SAT/Mios/Clause.hs
@@ -32,7 +32,7 @@ import SAT.Mios.Types
 -- This matches both of @Clause@ and @GClause@ in MiniSat.
 data Clause = Clause
               {
-               activity   :: !Double'  -- ^ activity of this clause
+               activity    :: !Double'  -- ^ activity of this clause
               , lits       :: !Stack    -- ^ literals and rank
 --            , protected  :: !Bool'    -- ^ protected from reduce
               }

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -120,7 +120,7 @@ instance StackFamily ClauseExtManager C.Clause where
     !b <- IORef.readIORef _keyVector
     if MV.length v - 1 <= n
       then do
-          let len = max 8 $ MV.length v
+          let len = max 8 $ div (MV.length v) 4
           v' <- MV.unsafeGrow v len
           b' <- growBy b len
           MV.unsafeWrite v' n c

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -281,7 +281,6 @@ newWatcherList n m = do let n' = int2lit (negate n) + 2
                         v <- MV.unsafeNew n'
                         mapM_  (\i -> MV.unsafeWrite v i =<< newManager m) [0 .. n' - 1]
                         V.unsafeFreeze v
---  V.replicateM (int2lit (negate n) + 2) (newManager m)
 
 -- | returns the watcher List for "Literal" /l/.
 {-# INLINE getNthWatcher #-}

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -241,7 +241,7 @@ pushClauseWithKey ClauseExtManager{..} !c k = do
   !b <- IORef.readIORef _keyVector
   if MV.length v - 1 <= n
     then do
-        let len = max 8 $ MV.length v
+        let len = max 8 $ div (MV.length v) 4
         v' <- MV.unsafeGrow v len
         b' <- growBy b len
         MV.unsafeWrite v' n c

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -316,14 +316,12 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> cLv) =
   ds  <- updateEMA emaDSlow lbd
   af  <- updateEMA emaAFast nas
   as  <- updateEMA emaASlow nas
-  void $ updateEMA emaCFast cLv
+  void $ updateEMA emaCDLvl cLv
   let filled = next <= count
       blockingRestart = filled && 1.25 * as < af
       forcingRestart = filled && 1.25 * ds < df
       lv' = if forcingRestart then 0 else bLv
-  void $ updateEMA emaBFast lv'
-  when (0 < dumpSolverStatMode config) $ do void $ updateEMA emaCSlow cLv
-                                            void $ updateEMA emaBSlow lv'
+  void $ updateEMA emaBDLvl lv'
   if (not blockingRestart && not forcingRestart)
     then return False
     else do incrementStat s (if blockingRestart then NumOfBlockRestart else NumOfRestart) 1
@@ -339,10 +337,8 @@ checkRestartCondition s@Solver{..} (fromIntegral -> lbd) (fromIntegral -> cLv) =
 emaLabels :: [(String, Solver -> EMA)]
 emaLabels = [ ("emaAFast", emaAFast)
             , ("emaASlow", emaASlow)
-            , ("emaBFast", emaBFast)
-            , ("emaBSlow", emaBSlow)
-            , ("emaCFast", emaCFast)
-            , ("emaCSlow", emaCSlow)
+            , ("emaBDLvl", emaBDLvl)
+            , ("emaCDLvl", emaCDLvl)
             , ("emaDFast", emaDFast)
             , ("emaDSlow", emaDSlow)
             ]

--- a/src/SAT/Mios/Criteria.hs
+++ b/src/SAT/Mios/Criteria.hs
@@ -1,7 +1,8 @@
 -- | (This is a part of MIOS.)
 -- Advanced heuristics library for 'SAT.Mios.Main'
 {-# LANGUAGE
-    MultiWayIf
+    BangPatterns
+  , MultiWayIf
   , RecordWildCards
   , ViewPatterns
   #-}
@@ -136,99 +137,39 @@ claRescaleActivityAfterRestart Solver{..} = do
 -- * @Left True@ if the clause is satisfied
 -- * @Right clause@ if the clause is enqueued successfully
 {-# INLINABLE clauseNew #-}
-clauseNew :: Solver -> Stack -> Bool -> IO (Either Bool Clause)
-clauseNew s@Solver{..} ps isLearnt = do
-  -- now ps[0] is the number of living literals
-  exit <- do
-    let
-      handle :: Int -> Int -> Int -> IO Bool
-      handle j l n      -- removes duplicates, but returns @True@ if this clause is satisfied
-        | j > n = return False
-        | otherwise = do
-            y <- getNth ps j
-            if | y == l    -> do                      -- finds a duplicate
-                   swapBetween ps j n
-                   modifyNth ps (subtract 1) 0
-                   handle j l (n - 1)
-               | - y == l  -> reset ps >> return True -- p and negateLit p occurs in ps
-               | otherwise -> handle (j + 1) l n
-      loopForLearnt :: Int -> IO Bool
-      loopForLearnt i = do
-        n <- get' ps
-        if n < i
-          then return False
-          else do
-              l <- getNth ps i
-              sat <- handle (i + 1) l n
-              if sat
-                then return True
-                else loopForLearnt $ i + 1
-      loop :: Int -> IO Bool
-      loop i = do
-        n <- get' ps
-        if n < i
-          then return False
-          else do
-              l <- getNth ps i     -- check the i-th literal's satisfiability
-              sat <- valueLit s l  -- any literal in ps is true
-              case sat of
-               1  -> reset ps >> return True
-               -1 -> do
-                 swapBetween ps i n
-                 modifyNth ps (subtract 1) 0
-                 loop i
-               _ -> do
-                 sat' <- handle (i + 1) l n
-                 if sat'
-                   then return True
-                   else loop $ i + 1
-    if isLearnt then loopForLearnt 1 else loop 1
+clauseNew :: Solver -> Stack -> IO (Either Bool Clause)
+clauseNew s@Solver{..} ps = do
+  n <- get' ps
+  sortStack ps
+  let loop :: Int -> Int -> Lit -> IO Bool
+      loop ((<= n) -> False) j _ = setNth ps 0 (j - 1) >> return False
+      loop !i !j !l' = do l <- getNth ps i -- check the i-th literal's satisfiability
+                          sat <- valueLit s l
+                          if | sat == LiftedT || negateLit l == l' -> reset ps >> return True
+                             | sat /= LiftedF && l /= l' -> setNth ps j l >> loop (i + 1) (j + 1) l
+                             | otherwise -> loop (i + 1) j l'
+  exit <- loop 1 1 LBottom
   k <- get' ps
   case k of
    0 -> return (Left exit)
-   1 -> do
-     l <- getNth ps 1
-     Left <$> enqueue s l NullClause
-   _ -> do
-    -- allocate clause:
-     c <- newClauseFromStack isLearnt ps
-     let lstack = lits c
-     when isLearnt $ do
-       -- Pick a second literal to watch:
-       let
-         findMax :: Int -> Int -> Int -> IO Int
-         findMax ((<= k) -> False) j _ = return j
-         findMax i j val = do
-           v' <- lit2var <$> getNth lstack i
-           varBumpActivity s v' -- this is a just good chance to bump activities of literals in this clause
-           a <- getNth assigns v'
-           b <- getNth level v'
-           if (a /= LBottom) && (val < b)
-             then findMax (i + 1) i b
-             else findMax (i + 1) j val
-       -- Let @max_i@ be the index of the literal with highest decision level
-       max_i <- findMax 1 1 0
-       swapBetween lstack 2 max_i
-       -- check literals occurences
-       -- x <- asList c
-       -- unless (length x == length (nub x)) $ error "new clause contains a element doubly"
-       -- Bumping:
-       claBumpActivity s c -- newly learnt clauses should be considered active
-     -- Add clause to watcher lists:
-     l1 <- getNth lstack 1
-     l2 <- getNth lstack 2
-     pushClauseWithKey (getNthWatcher watches (negateLit l1)) c 0
-     pushClauseWithKey (getNthWatcher watches (negateLit l2)) c 0
-     return (Right c)
+   1 -> do l <- getNth ps 1
+           Left <$> enqueue s l NullClause
+   _ -> do c <- newClauseFromStack False ps
+           let lstack = lits c
+           l1 <- getNth lstack 1
+           l2 <- getNth lstack 2
+           pushClauseWithKey (getNthWatcher watches (negateLit l1)) c 0
+           pushClauseWithKey (getNthWatcher watches (negateLit l2)) c 0
+           return (Right c)
 
 -- | returns @False@ if a conflict has occured.
--- This function is called only before the solving phase to register the given clauses.
+-- This function is called only before the solving phase to register the given clauses (not learnt).
 {-# INLINABLE addClause #-}
 addClause :: Solver -> Stack -> IO Bool
 addClause s@Solver{..} vecLits = do
-  result <- clauseNew s vecLits False
+  result <- clauseNew s vecLits
   case result of
-   Left b  -> return b   -- No new clause was returned becaues a confilct occured or the clause is a literal
+   Left b  -> return b -- No clause is returned becaues a confilct occured or the clause is a literal
    Right c -> pushTo clauses c >> return True
 
 -------------------------------------------------------------------------------- Clause Metrics

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -64,14 +64,13 @@ newLearntClause s@Solver{..} ps = do
            let lstack = lits c
                findMax :: Int -> Int -> Int -> IO Int -- Pick a second literal to watch:
                findMax ((<= k) -> False) j _ = return j
-               findMax i j val = do
-                 v <- lit2var <$> getNth lstack i
-                 a <- getNth assigns v
-                 b <- getNth level v
-                 if (a /= LBottom) && (val < b)
-                   then findMax (i + 1) i b
-                   else findMax (i + 1) j val
-           swapBetween lstack 2 =<< findMax 1 1 0 -- Let @max_i@ be the index of the literal with highest decision level
+               findMax i j val = do v <- lit2var <$> getNth lstack i
+                                    a <- getNth assigns v
+                                    b <- getNth level v
+                                    if (a /= LBottom) && (val < b)
+                                      then findMax (i + 1) i b
+                                      else findMax (i + 1) j val
+           swapBetween lstack 2 =<< findMax 1 1 0 -- get the index of the literal with highest level
            -- Bump, enqueue, store clause:
            claBumpActivity s c
            -- Add clause to all managers
@@ -84,7 +83,7 @@ newLearntClause s@Solver{..} ps = do
            unsafeEnqueue s l1 c
            -- Since unsafeEnqueue updates the 1st literal's level, setLBD should be called after unsafeEnqueue
            lbd <- lbdOf s (lits c)
-           set' (rank c) lbd
+           setRank c lbd
            -- assert (0 < rank c)
            -- set' (protected c) True
            return lbd
@@ -142,7 +141,7 @@ analyze s@Solver{..} confl = do
   dl <- decisionLevel s
   let loopOnClauseChain :: Clause -> Lit -> Int -> Int -> Int -> IO Int
       loopOnClauseChain c p ti bl pathC = do -- p : literal, ti = trail index, bl = backtrack level
-        d <- get' (rank c)
+        d <- getRank c
         when (0 /= d) $ claBumpActivity s c
         -- update LBD like #Glucose4.0
         when (2 < d) $ do
@@ -150,7 +149,7 @@ analyze s@Solver{..} confl = do
           when (nblevels + 1 < d) $ -- improve the LBD
             -- when (d <= 30) $ set' (protected c) True -- 30 is `lbLBDFrozenClause`
             -- seems to be interesting: keep it fro the next round
-            set' (rank c) nblevels    -- Update it
+            setRank c nblevels     --  Update it
         sc <- get' c
         let lstack = lits c
             loopOnLiterals :: Int -> Int -> Int -> IO (Int, Int)
@@ -169,7 +168,7 @@ analyze s@Solver{..} confl = do
                           -- UPDATEVARACTIVITY: glucose heuristics
                           r <- getNth reason v
                           when (r /= NullClause) $ do
-                            ra <- get' (rank r)
+                            ra <- getRank r
                             when (0 /= ra) $ pushTo an'lastDL q
                           -- end of glucose heuristics
                           loopOnLiterals (j + 1) b (pc + 1)
@@ -519,7 +518,7 @@ sortClauses s cm limit' = do
           then do setNth keys (2 * i) 0
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)               -- Second one... based on LBD
-                  rLBD <- fromIntegral <$> get' (rank c)       -- above the level
+                  rLBD <- fromIntegral <$> getRank c           -- above the level
                   rNDD <- fromIntegral <$> nddOf s (lits c)    -- under the level
                   let r = if rNDD == 1                         -- this implies rLBD == 1.
                           then 1

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -499,8 +499,8 @@ sortClauses s cm limit' = do
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
   updateNDD s
-  cl <- getEMA (emaCFast s)
-  surface <- if cl == 0 then return 0 else (/ cl) <$> getEMA (emaBFast s)  -- 0 <=backjumped level / coflict level < 1.0
+  cl <- getEMA (emaCDLvl s)
+  surface <- if cl == 0 then return 0 else (/ cl) <$> getEMA (emaBDLvl s)  -- 0 <=backjumped level / coflict level < 1.0
   let shiftLBD = activityWidth
       shiftIndex = shiftL 1 indexWidth
       am = fromIntegral activityMax :: Double

--- a/src/SAT/Mios/OptionParser.hs
+++ b/src/SAT/Mios/OptionParser.hs
@@ -57,7 +57,7 @@ miosDefaultOption = MiosProgramOption
   , _confRestartF = restartExpansionF defaultConfiguration
   , _confRestartS = restartExpansionS defaultConfiguration
   --, _confRandomDecisionRate = randomDecisionRate defaultConfiguration
-  , _confMaxSize = 5000000    -- 5,000,000 = 5M
+  , _confMaxSize = 4000000    -- 4,000,000 = 4M
   , _confCheckAnswer = False
   , _confVerbose = False
   , _confBenchmark = -1

--- a/src/SAT/Mios/OptionParser.hs
+++ b/src/SAT/Mios/OptionParser.hs
@@ -32,7 +32,7 @@ data MiosProgramOption = MiosProgramOption
                      , _confRestartF          :: Double
                      , _confRestartS          :: Double
 --                     , _confRandomDecisionRate :: Int
-                     , _confMaxSize           :: Int
+                     , _confMaxClauses        :: Int
                      , _confCheckAnswer       :: Bool
                      , _confVerbose           :: Bool
                      , _confBenchmark         :: Integer
@@ -57,7 +57,7 @@ miosDefaultOption = MiosProgramOption
   , _confRestartF = restartExpansionF defaultConfiguration
   , _confRestartS = restartExpansionS defaultConfiguration
   --, _confRandomDecisionRate = randomDecisionRate defaultConfiguration
-  , _confMaxSize = 4000000    -- 4,000,000 = 4M
+  , _confMaxClauses = 40000000   -- 40,000,000 = 40M
   , _confCheckAnswer = False
   , _confVerbose = False
   , _confBenchmark = -1
@@ -92,7 +92,7 @@ miosOptions =
 --    (ReqArg (\v c -> c { _confRandomDecisionRate = read v }) (show (_confRandomDecisionRate miosDefaultOption)))
 --    "[solver] random selection rate (0 - 1000)"
   , Option [] ["maxsize"]
-    (ReqArg (\v c -> c { _confMaxSize = read v }) (show (_confMaxSize miosDefaultOption)))
+    (ReqArg (\v c -> c { _confMaxClauses = read v }) (show (_confMaxClauses miosDefaultOption)))
     "[solver] limit of the number of variables"
   , Option [':'] ["validate-assignment"]
     (NoArg (\c -> c { _validateAssignment = True }))

--- a/src/SAT/Mios/OptionParser.hs
+++ b/src/SAT/Mios/OptionParser.hs
@@ -57,7 +57,7 @@ miosDefaultOption = MiosProgramOption
   , _confRestartF = restartExpansionF defaultConfiguration
   , _confRestartS = restartExpansionS defaultConfiguration
   --, _confRandomDecisionRate = randomDecisionRate defaultConfiguration
-  , _confMaxClauses = 40000000   -- 40,000,000 = 40M
+  , _confMaxClauses = 16000000   -- 16,000,000 = 16M
   , _confCheckAnswer = False
   , _confVerbose = False
   , _confBenchmark = -1

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -88,10 +88,8 @@ data Solver = Solver
                 -------- restart heuristics #62, clause evaluation criteria #74
               , emaAFast    :: !EMA              -- ^ Number of Assignments Fast
               , emaASlow    :: !EMA              -- ^ Number of Assignments Slow
-              , emaBFast    :: !EMA              -- ^ Backjumped and Restart Dicision Level Fast
-              , emaBSlow    :: !EMA              -- ^ Backjumped and Restart Dicision Level Slow
-              , emaCFast    :: !EMA              -- ^ Conflicting Level Fast
-              , emaCSlow    :: !EMA              -- ^ Conflicting Level Slow
+              , emaBDLvl    :: !EMA              -- ^ Backjumped and Restart Dicision Level
+              , emaCDLvl    :: !EMA              -- ^ Conflicting Level
               , emaDFast    :: !EMA              -- ^ (Literal Block) Distance Fast
               , emaDSlow    :: !EMA              -- ^ (Literal Block) Distance Slow
               , nextRestart :: !Int'             -- ^ next restart in number of conflict
@@ -142,10 +140,8 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     -- restart heuristics #62
     <*> fastEma                            -- emaAFast
     <*> slowEma                            -- emaASlow
-    <*> fastEma                            -- emaBFast
-    <*> slowEma                            -- emaBSlow
-    <*> fastEma                            -- emaCFast
-    <*> slowEma                            -- emaCSlow
+    <*> newEMA True (2 ^ 10)               -- emaBDLvl
+    <*> newEMA True (2 ^ 10)               -- emaCDLvl
     <*> fastEma                            -- emaDFast
     <*> slowEma                            -- emaDSlow
     <*> new' 100                           -- nextRestart

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -104,7 +104,7 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     -- Clause Database
     <$> newManager dummy_nc                -- clauses
     <*> newManager 2000                    -- learnts
-    <*> newWatcherList nv 2                -- watches
+    <*> newWatcherList nv 512              -- watches
     -- Assignment Management
     <*> newVec nv LBottom                  -- assigns
     <*> newVec nv LBottom                  -- phases

--- a/src/SAT/Mios/Solver.hs
+++ b/src/SAT/Mios/Solver.hs
@@ -82,7 +82,7 @@ data Solver = Solver
               , an'lastDL  :: !Stack             -- ^ last decision level used in 'SAT.Mios.Main.analyze'
               , clsPool    :: ClausePool         -- ^ clause recycler
               , litsLearnt :: !Stack             -- ^ used in 'SAT.Mios.Main.analyze' and 'SAT.Mios.Main.search' to create a learnt clause
-              , stats      :: !(Vec [Int])       -- ^ statistics information holder
+              , stats      :: !(Vec Int)         -- ^ statistics information holder
               , lbd'seen   :: !(Vec Int)         -- ^ used in lbd computation
               , lbd'key    :: !Int'              -- ^ used in lbd computation
                 -------- restart heuristics #62, clause evaluation criteria #74
@@ -104,7 +104,7 @@ newSolver conf (CNFDescription nv dummy_nc _) =
     -- Clause Database
     <$> newManager dummy_nc                -- clauses
     <*> newManager 2000                    -- learnts
-    <*> newWatcherList nv 512              -- watches
+    <*> newWatcherList nv 1                -- watches
     -- Assignment Management
     <*> newVec nv LBottom                  -- assigns
     <*> newVec nv LBottom                  -- phases

--- a/src/SAT/Mios/Types.hs
+++ b/src/SAT/Mios/Types.hs
@@ -321,7 +321,7 @@ data MiosConfiguration = MiosConfiguration
                          , emaCoeffs          :: !(Int, Int) -- ^ the coefficients for restarts
                          , restartExpansionB  :: !Double     -- ^ Blocking restart expansion factor
                          , restartExpansionF  :: !Double     -- ^ Forcing restart expansion factor
-                         , restartExpansionS  :: !Double     -- ^ static Steps betwen restarts
+                         , restartExpansionS  :: !Double     -- ^ static Steps between restarts
                          }
   deriving (Eq, Ord, Read, Show)
 
@@ -333,7 +333,7 @@ data MiosConfiguration = MiosConfiguration
 -- * Mios-1.2     uses @(0.95, 0.999, 0)@.
 --
 defaultConfiguration :: MiosConfiguration
-defaultConfiguration = MiosConfiguration 0.95 0.999 0 (ef, es) 1.19 1.01 100
+defaultConfiguration = MiosConfiguration 0.95 0.999 0 (ef, es) 1.20 1.01 100
   where ef = (2 :: Int) ^ ( 5 :: Int)
         es = (2 :: Int) ^ (14 :: Int)
 

--- a/src/SAT/Mios/Vec.hs
+++ b/src/SAT/Mios/Vec.hs
@@ -98,6 +98,7 @@ instance VecFamily (UVector Int) Int where
   growBy = UV.unsafeGrow
   asList v = mapM (UV.unsafeRead v) [0 .. UV.length v - 1]
 
+{-
 -- Note: type @[Int]@ is selected for 'UVector' not to export it.
 data instance Vec [Int] = Vec (UVector Int)
 
@@ -119,6 +120,7 @@ instance VecFamily (Vec [Int]) Int where
   {-# SPECIALIZE INLINE growBy :: Vec [Int] -> Int -> IO (Vec [Int]) #-}
   growBy (Vec v) n = Vec <$> UV.unsafeGrow v n
   asList (Vec v) = mapM (getNth v) [0 .. UV.length v - 1]
+-}
 
 {- NOT IN USE
 data instance Vec [Double] = Vec (UVector Double)
@@ -185,6 +187,9 @@ instance VecFamily ByteArrayInt Int where
                   BA.writeByteArray v 0 (0 :: Int)
                   BA.setByteArray v 1 n k
                   return $ ByteArrayInt v
+  growBy (ByteArrayInt v) n = do v' <- BA.newByteArray (BA.sizeofMutableByteArray v + 8 * n)
+                                 BA.copyMutableByteArray v' 0 v 0 (BA.sizeofMutableByteArray v)
+                                 return (ByteArrayInt v')
   asList (ByteArrayInt v) = mapM (BA.readByteArray v) [0 .. div (BA.sizeofMutableByteArray v) 8 - 1]
 
 instance VecFamily ByteArrayDouble Double where


### PR DESCRIPTION
- use `Vec Int` instead of `Vec [Int]` for keyVector in ClauseManager
- reduce the expansion factor for growable vectors
- `newWatcherList` ditched `M.replicate` :exclamation: 
- set the initial size of watcher list to 1 instead of 8
- implement `growBy` for `Vec Int`
- use `ByteString.uncons` instead of a pair of `head` and `tail` #78
- reimplement a literal checker in `causeNew` #78 
- stop checking polarity of literals during clause injection #78 
- absorb `rank` into `lits` to reduce the number of object allocation #78 
- use gitrev for help message #78 


