### PR TITLE
sort clauses without proxy vectors

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-76:
+  mios-82.0:
     source-dirs:     app
     main:            mios.hs
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-82.0:
+  mios-84.1:
     source-dirs:     app
     main:            mios.hs
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -68,13 +68,3 @@ executables:
           buildable: true
         else:
           buildable: false
-  cnf-stat:
-    source-dirs:     utils
-    main:            cnf-stat.hs
-    dependencies:    mios
-    when:
-      - condition:   flag(utils)
-        then:
-          buildable: true
-        else:
-          buildable: false

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "#72#73#74#77#78#80#76 https://github.com/shnarazk/mios"
+versionId = "#82.0 https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "#82.0 https://github.com/shnarazk/mios"
+versionId = "#84.1 https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -494,15 +494,15 @@ sortClauses s cm limit' = do
   n <- get' cm
   -- assert (n < indexMax)
   vec <- getClauseVector cm
-  bvec <- getKeyVector cm
-  keys <- newVec (2 * n) 0 :: IO (Vec Int)
+  kvec <- getKeyVector cm
+--  keys <- newVec (2 * n) 0 :: IO (Vec Int)
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
   updateNDD s
   cl <- getEMA (emaCDLvl s)
   surface <- if cl == 0 then return 0 else (/ cl) <$> getEMA (emaBDLvl s)  -- 0 <=backjumped level / coflict level < 1.0
   let shiftLBD = activityWidth
-      shiftIndex = shiftL 1 indexWidth -- store a shifted value of index (**)
+      -- shiftIndex = shiftL 1 indexWidth -- store a shifted value of index (**)
       am = fromIntegral activityMax :: Double
       scaleAct :: Double -> Int
       scaleAct x
@@ -511,11 +511,11 @@ sortClauses s cm limit' = do
       assignKey :: Int -> Int -> IO Int
       assignKey ((< n) -> False) t = return t
       assignKey i t = do
-        setNth keys (2 * i + 1) $ shiftIndex + i
+        -- setNth keys (2 * i + 1) $ shiftIndex + i
         c <- getNth vec i
         k <- get' c
         if k == 2                  -- Main criteria. Like in MiniSat we keep all binary clauses
-          then do setNth keys (2 * i) 0
+          then do setNth kvec i 0
                   assignKey (i + 1) (t + 1)
           else do a <- get' (activity c)                       -- Second one... based on LBD
                   rLBD <- fromIntegral <$> getRank c           -- above the level
@@ -527,46 +527,46 @@ sortClauses s cm limit' = do
                   let d =if | l -> 0
                             | a < at -> rankMax
                             | otherwise ->  min rankMax r                -- rank can be one
-                  setNth keys (2 * i) $ shiftL d shiftLBD + scaleAct a
+                  setNth kvec i $ shiftL d shiftLBD + scaleAct a
                   assignKey (i + 1) $ if l then t + 1 else t
   limit <- max limit' <$> assignKey 0 0
   -- 2: sort keyVector
-  let limit2 = 2 * limit
-      sortOnRange :: Int -> Int -> IO ()
+  let sortOnRange :: Int -> Int -> IO ()
       sortOnRange left right
-        | limit2 < left = return ()
+        | limit < left = return ()
         | left >= right = return ()
-        | left + 2 == right = do
-            a <- getNth keys left
-            b <- getNth keys right
-            unless (a < b) $ do setNth keys left b
-                                setNth keys right a
-                                swapBetween keys (left + 1) (right + 1)
+        | left + 1 == right = do
+            a <- getNth kvec left
+            b <- getNth kvec right
+            unless (a < b) $ do setNth kvec left b
+                                setNth kvec right a
+                                swapBetween vec left right -- kvec (left + 1) (right + 1)
         | otherwise = do
-            let p = 2 * div (left + right) 4
-            pivot <- getNth keys p
-            swapBetween keys p left -- set a sentinel for r'
-            swapBetween keys (p + 1) (left + 1)
+            let p = div (left + right) 2
+            pivot <- getNth kvec p
+            swapBetween kvec p left -- set a sentinel for r'
+            swapBetween vec p left  -- kvec (p + 1) (left + 1)
             let nextL :: Int -> IO Int
                 nextL i@((<= right) -> False) = return i
-                nextL i = do v <- getNth keys i; if v < pivot then nextL (i + 2) else return i
+                nextL i = do v <- getNth kvec i; if v < pivot then nextL (i + 1) else return i
                 nextR :: Int -> IO Int
-                nextR i = do v <- getNth keys i; if pivot < v then nextR (i - 2) else return i
+                nextR i = do v <- getNth kvec i; if pivot < v then nextR (i - 1) else return i
                 divide :: Int -> Int -> IO Int
                 divide l r = do
                   l' <- nextL l
                   r' <- nextR r
                   if l' < r'
-                    then do swapBetween keys l' r'
-                            swapBetween keys (l' + 1) (r' + 1)
-                            divide (l' + 2) (r' - 2)
+                    then do swapBetween kvec l' r'
+                            swapBetween vec l' r'
+                            divide (l' + 1) (r' - 1)
                     else return r'
-            m <- divide (left + 2) right
-            swapBetween keys left m
-            swapBetween keys (left + 1) (m + 1)
-            sortOnRange left (m - 2)
-            sortOnRange (m + 2) right
-  sortOnRange 0 $ 2 * (n - 1)
+            m <- divide (left + 1) right
+            swapBetween kvec left m
+            swapBetween vec left m  -- bvec (left + 1) (m + 1)
+            sortOnRange left (m - 1)
+            sortOnRange (m + 1) right
+  sortOnRange 0 (n - 1)
+{-
   -- 3: place clauses in 'vec' based on the order stored in 'keys'.
   -- To recycle existing clauses, we must reserve all clauses for now.
   let seek :: Int -> IO ()
@@ -588,6 +588,7 @@ sortClauses s cm limit' = do
           sweep i -- (indexMax .&. bits)
         seek $ i + 1
   seek 0
+-}
   return limit
 
 -- | #M22


### PR DESCRIPTION
### precondition
- `learnts` doesn't use the key vector. :arrow_right:  OK.

### validation of ebbfe71d35b6a6032a0b6923ba8088605e7a83ac

```
parallel "mios-{} --dump=1 -X test/data/44bits_11.dimacs.cnf " ::: 76 84.0 84.1
NumOfBackjump,NumOfRestart,NumOfBlockRestart,NumOfGeometricRestart,NumOfPropagation,NumOfReduction,NumOfClause,NumOfLearnt,NumOfVariable,NumOfAssigned,emaAFast,emaASlow,emaBDLvl,emaCDLvl,emaDFast,emaDSlow
911718,61,58,0,77135508,245,15081,6540,594,609,115.772,109.656,13.152,14.216,8.339,9.288
911718,61,58,0,77135508,245,15081,6540,594,609,115.772,109.656,13.152,14.216,8.339,9.288
911718,61,58,0,77135508,245,15081,6540,594,609,115.772,109.656,13.152,14.216,8.339,9.288
```
