### PR TITLE
2018-04 recycle proxy

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-85.1:
+  mios-85.2:
     source-dirs:     app
     main:            mios.hs
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -54,9 +54,12 @@ executables:
     when:
       - condition: flag(llvm)
         then:
+          ghc-options:          -j -O2 -funbox-strict-fields -fllvm -optlo-O3 -optlc-O3 -fwarn-missing-signatures
+                                -rtsopts -with-rtsopts=-M4g
           ghc-prof-options:	-j -O2 -funbox-strict-fields -fllvm -optlo-O3 -fprof-auto -rtsopts
-                                --rtsopts-with="-H16M -A16M"
         else:
+          ghc-options:          -j -O2 -funbox-strict-fields -msse2 -fwarn-missing-signatures
+                                -rtsopts -with-rtsopts=-M4g
           ghc-prof-options:	-j -O2 -funbox-strict-fields -fprof-auto -rtsopts
   cnf-stat:
     source-dirs:     utils

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-79:
+  mios-85.0:
     source-dirs:     app
     main:            mios.hs
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -55,11 +55,11 @@ executables:
       - condition: flag(llvm)
         then:
           ghc-options:          -j -O2 -funbox-strict-fields -fllvm -optlo-O3 -optlc-O3 -fwarn-missing-signatures
-                                -rtsopts -with-rtsopts=-M4g
+                                -rtsopts -with-rtsopts=-M7g
           ghc-prof-options:	-j -O2 -funbox-strict-fields -fllvm -optlo-O3 -fprof-auto -rtsopts
         else:
           ghc-options:          -j -O2 -funbox-strict-fields -msse2 -fwarn-missing-signatures
-                                -rtsopts -with-rtsopts=-M4g
+                                -rtsopts -with-rtsopts=-M7g
           ghc-prof-options:	-j -O2 -funbox-strict-fields -fprof-auto -rtsopts
   cnf-stat:
     source-dirs:     utils

--- a/package.yaml
+++ b/package.yaml
@@ -55,11 +55,11 @@ executables:
       - condition: flag(llvm)
         then:
           ghc-options:          -j -O2 -funbox-strict-fields -fllvm -optlo-O3 -optlc-O3 -fwarn-missing-signatures
-                                -rtsopts -with-rtsopts=-M7g
+                                -rtsopts -with-rtsopts=-M7g -with-rtsopts=-A8m
           ghc-prof-options:	-j -O2 -funbox-strict-fields -fllvm -optlo-O3 -fprof-auto -rtsopts
         else:
           ghc-options:          -j -O2 -funbox-strict-fields -msse2 -fwarn-missing-signatures
-                                -rtsopts -with-rtsopts=-M7g
+                                -rtsopts -with-rtsopts=-M7g -with-rtsopts=-A8m
           ghc-prof-options:	-j -O2 -funbox-strict-fields -fprof-auto -rtsopts
   cnf-stat:
     source-dirs:     utils

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   source-dirs:       src
 
 executables:
-  mios-85.0:
+  mios-85.1:
     source-dirs:     app
     main:            mios.hs
     dependencies:

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -86,7 +86,7 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
              UserInterrupt -> putStrLn "User interrupt recieved."
              ThreadKilled  -> reportResult opts t0 =<< readMVar token
              HeapOverflow  -> if -1 == _confBenchmark opts
-                              then putStrLn "Abort: a too large problem or heap exhausted"
+                              then putStrLn "Abort: a too large problem or heap exhausted (use '+RTS -M16g' if you need)"
                               else reportResult opts t0 (Left OutOfMemory)
              e -> if -1 == _confBenchmark opts then print e else reportResult opts t0 (Left TimeOut)
          ) $ do

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -112,11 +112,15 @@ executeSolver _ = return ()
 --   * other bigger values are used for aborted cases.
 reportResult :: MiosProgramOption -> Integer -> SolverResult -> IO ()
 -- abnormal cases, catching 'too large CNF', 'timeout' for now.
-reportResult opts@(_targetFile -> Just cnfFile) _ (Left flag) =
-  putStrLn ("\"" ++ takeWhile (' ' /=) versionId ++ "\","
-             ++ show (_confBenchSeq opts) ++ ","
-             ++ "\"" ++ cnfFile ++ "\","
-             ++ show (_confBenchmark opts) ++ "," ++ show (fromEnum flag))
+reportResult opts@(_targetFile -> Just cnfFile) t0 (Left flag) = do
+  t2 <- reportElapsedTime (_confVerbose opts) ("## [" ++ showPath cnfFile ++ "] Total: ") t0
+  when (0 <= _confBenchmark opts) $ do
+    let fromPico = 1000000000000 :: Double
+    putStrLn ("\"" ++ takeWhile (' ' /=) versionId ++ "\","
+              ++ show (_confBenchSeq opts) ++ ","
+              ++ "\"" ++ cnfFile ++ "\","
+              ++ showFFloat (Just 3) (fromIntegral (t2 - t0) / fromPico) ","
+              ++ show (fromEnum flag))
 
 -- solver terminated normally
 reportResult opts@(_targetFile -> Just cnfFile) t0 (Right result) = do

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "#72#73#74#77#78#80#79 https://github.com/shnarazk/mios"
+versionId = "#85.0 https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -52,7 +52,7 @@ import SAT.Mios.Validator
 
 -- | version name
 versionId :: String
-versionId = "#85.0 https://github.com/shnarazk/mios"
+versionId = "#85.1 https://github.com/shnarazk/mios"
 
 reportElapsedTime :: Bool -> String -> Integer -> IO Integer
 reportElapsedTime False _ 0 = return 0

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -95,7 +95,7 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
                              checkTime remain = do
                                -- putStrLn $ "waiting in " ++ show (div remain toPico) ++ " sec"
                                threadDelay $ div (fromIntegral remain) (1000 * 1000)   --  requires micro second
-                               elapsed <- subtract t0 <$> getCPUTime
+                               elapsed <- getCPUTime
                                -- putStrLn $ "wasted in " ++ show (div elapsed toPico) ++ " sec"
                                when (elapsed < required) $ checkTime (required - elapsed)
                          checkTime required
@@ -129,7 +129,7 @@ reportResult opts@(_targetFile -> Just cnfFile) t0 (Left flag) = do
     putStrLn ("\"" ++ takeWhile (' ' /=) versionId ++ "\","
               ++ show (_confBenchSeq opts) ++ ","
               ++ "\"" ++ cnfFile ++ "\","
-              ++ showFFloat (Just 3) (fromIntegral (t2 - t0) / fromPico) ","
+              ++ showFFloat (Just 3) (fromIntegral t2 / fromPico) ","
               ++ show (fromEnum flag))
 
 -- solver terminated normally
@@ -163,7 +163,7 @@ reportResult opts@(_targetFile -> Just cnfFile) t0 (Right result) = do
       ++ show (_confBenchSeq opts) ++ ","
       ++ "\"" ++ cnfFile ++ "\","
       ++ if valid
-         then showFFloat (Just 3) (fromIntegral (t2 - t0) / fromPico) "," ++ show phase
+         then showFFloat (Just 3) (fromIntegral t2 / fromPico) "," ++ show phase
          else show (_confBenchmark opts) ++ "," ++ show (fromEnum InternalInconsistent)
 
 reportResult _ _ _ = return ()

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -86,7 +86,7 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
              UserInterrupt -> putStrLn "User interrupt recieved."
              ThreadKilled  -> reportResult opts t0 =<< readMVar token
              HeapOverflow  -> if -1 == _confBenchmark opts
-                              then putStrLn "Abort: out of heap memory"
+                              then putStrLn "Abort: a too large problem or heap exhausted"
                               else reportResult opts t0 (Left OutOfMemory)
              e -> if -1 == _confBenchmark opts then print e else reportResult opts t0 (Left TimeOut)
          ) $ do

--- a/src/SAT/Mios.hs
+++ b/src/SAT/Mios.hs
@@ -76,10 +76,6 @@ executeSolver opts@(_targetFile -> (Just cnfFile)) = do
   solverId <- myThreadId
   (desc, cls) <- parseCNF (_targetFile opts)
   -- when (_numberOfVariables desc == 0) $ error $ "couldn't load " ++ show cnfFile
-  when (_confMaxClauses opts < _numberOfClauses desc) $
-    if -1 == _confBenchmark opts
-      then errorWithoutStackTrace $ "ABORT: too many clauses to solve, " ++ show desc
-      else reportResult opts 0 (Left OutOfMemory) >> killThread solverId
   token <- newEmptyMVar --  :: IO (MVar (Maybe Solver))
   t0 <- reportElapsedTime False "" $ if _confVerbose opts || 0 <= _confBenchmark opts then -1 else 0
   handle (\case

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -312,4 +312,4 @@ allocateKeyVectorSize  ClauseExtManager{..} n' = do
     then do v' <- newVec n' 0
             IORef.writeIORef _keyVector v'
             return v'
-    else return b
+    else return v

--- a/src/SAT/Mios/ClauseManager.hs
+++ b/src/SAT/Mios/ClauseManager.hs
@@ -19,8 +19,8 @@ module SAT.Mios.ClauseManager
        , ClauseExtManager
        , pushClauseWithKey
        , getKeyVector
-       , allocateKeyVectorSize
        , markClause
+--       , allocateKeyVectorSize
          -- * WatcherList
        , WatcherList
        , newWatcherList

--- a/src/SAT/Mios/Main.hs
+++ b/src/SAT/Mios/Main.hs
@@ -494,8 +494,7 @@ sortClauses s cm limit' = do
   n <- get' cm
   -- assert (n < indexMax)
   vec <- getClauseVector cm
-  bvec <- getKeyVector cm
-  keys <- newVec (2 * n) 0 :: IO (Vec Int)
+  keys <- allocateKeyVectorSize cm (2 * n) -- newVec (2 * n) 0 :: IO (Vec Int)
   at <- (0.1 *) . (/ fromIntegral n) <$> get' (claInc s) -- activity threshold
   -- 1: assign keys
   updateNDD s
@@ -575,15 +574,12 @@ sortClauses s cm limit' = do
         bits <- getNth keys (2 * i + 1)
         when (indexMax < bits) $ do
           c <- getNth vec i
-          d <- getNth bvec i
           -- setNth keys i i
           let sweep k = do k' <- (indexMax .&.) <$> getNth keys (2 * k + 1)
                            setNth keys (2 * k + 1) (indexMax .&. k) -- back to the real index from (**)
                            if k' == i
                              then do setNth vec k c
-                                     setNth bvec k d
                              else do getNth vec k' >>= setNth vec k
-                                     getNth bvec k' >>= setNth bvec k
                                      sweep k'
           sweep i -- (indexMax .&. bits)
         seek $ i + 1

--- a/src/SAT/Mios/OptionParser.hs
+++ b/src/SAT/Mios/OptionParser.hs
@@ -32,7 +32,6 @@ data MiosProgramOption = MiosProgramOption
                      , _confRestartF          :: Double
                      , _confRestartS          :: Double
 --                     , _confRandomDecisionRate :: Int
-                     , _confMaxClauses        :: Int
                      , _confCheckAnswer       :: Bool
                      , _confVerbose           :: Bool
                      , _confBenchmark         :: Integer
@@ -57,7 +56,6 @@ miosDefaultOption = MiosProgramOption
   , _confRestartF = restartExpansionF defaultConfiguration
   , _confRestartS = restartExpansionS defaultConfiguration
   --, _confRandomDecisionRate = randomDecisionRate defaultConfiguration
-  , _confMaxClauses = 16000000   -- 16,000,000 = 16M
   , _confCheckAnswer = False
   , _confVerbose = False
   , _confBenchmark = -1
@@ -91,9 +89,6 @@ miosOptions =
 --  , Option ['r'] ["random-decision-rate"]
 --    (ReqArg (\v c -> c { _confRandomDecisionRate = read v }) (show (_confRandomDecisionRate miosDefaultOption)))
 --    "[solver] random selection rate (0 - 1000)"
-  , Option [] ["maxsize"]
-    (ReqArg (\v c -> c { _confMaxClauses = read v }) (show (_confMaxClauses miosDefaultOption)))
-    "[solver] limit of the number of given clauses"
   , Option [':'] ["validate-assignment"]
     (NoArg (\c -> c { _validateAssignment = True }))
     "[solver] read an assignment from STDIN and validate it"

--- a/src/SAT/Mios/Vec.hs
+++ b/src/SAT/Mios/Vec.hs
@@ -24,7 +24,7 @@ module SAT.Mios.Vec
        , StackFamily (..)
        , Stack
        , newStackFromList
-       , realLengthOfStack
+       , realLength
        , sortStack
        )
        where
@@ -212,6 +212,11 @@ instance VecFamily ByteArrayDouble Double where
                   return $ ByteArrayDouble v
   asList (ByteArrayDouble v) = mapM (BA.readByteArray v) [0 .. div (BA.sizeofMutableByteArray v) 8 - 1]
 
+-- | returns the number of allocated slots
+{-# INLINE realLength #-}
+realLength :: Vec Int -> Int
+realLength (ByteArrayInt v) = div (BA.sizeofMutableByteArray v) 8
+
 -------------------------------------------------------------------------------- SingleStorage
 
 -- | Interface for single (one-length vector) mutable data
@@ -322,11 +327,6 @@ newStackFromList l = do
       loop [] _ = return $ ByteArrayInt v
       loop (x:l') i = BA.writeByteArray v i x >> loop l' (i + 1)
   loop (length l : l) 0
-
--- | returns the number of allocated slots
-{-# INLINE realLengthOfStack #-}
-realLengthOfStack :: Stack -> Int
-realLengthOfStack (ByteArrayInt v) = div (BA.sizeofMutableByteArray v) 8
 
 -- | sort the content of a stack, in small-to-large order.
 {-# INLINABLE sortStack #-}

--- a/src/SAT/Mios/Vec.hs
+++ b/src/SAT/Mios/Vec.hs
@@ -98,69 +98,6 @@ instance VecFamily (UVector Int) Int where
   growBy = UV.unsafeGrow
   asList v = mapM (UV.unsafeRead v) [0 .. UV.length v - 1]
 
-{-
--- Note: type @[Int]@ is selected for 'UVector' not to export it.
-data instance Vec [Int] = Vec (UVector Int)
-
-instance VecFamily (Vec [Int]) Int where
-  {-# SPECIALIZE INLINE getNth :: Vec [Int] -> Int -> IO Int #-}
-  getNth (Vec v) = UV.unsafeRead v
-  {-# SPECIALIZE INLINE setNth :: Vec [Int] -> Int -> Int -> IO () #-}
-  setNth (Vec v) = UV.unsafeWrite v
-  {-# SPECIALIZE INLINE reset :: Vec [Int] -> IO () #-}
-  reset (Vec v) = setNth v 0 0
-  {-# SPECIALIZE INLINE modifyNth :: Vec [Int] -> (Int -> Int) -> Int -> IO () #-}
-  modifyNth (Vec v) = UV.unsafeModify v
-  {-# SPECIALIZE INLINE swapBetween :: Vec [Int] -> Int -> Int -> IO () #-}
-  swapBetween (Vec v) = UV.unsafeSwap v
-  {-# SPECIALIZE INLINE newVec :: Int -> Int -> IO (Vec [Int]) #-}
-  newVec n x = Vec <$> newVec (n + 1) x
-  {-# SPECIALIZE INLINE setAll :: Vec [Int] -> Int -> IO () #-}
-  setAll (Vec v) = UV.set v
-  {-# SPECIALIZE INLINE growBy :: Vec [Int] -> Int -> IO (Vec [Int]) #-}
-  growBy (Vec v) n = Vec <$> UV.unsafeGrow v n
-  asList (Vec v) = mapM (getNth v) [0 .. UV.length v - 1]
--}
-
-{- NOT IN USE
-data instance Vec [Double] = Vec (UVector Double)
-
-instance VecFamily (UVector Double) Double where
-  {-# SPECIALIZE INLINE getNth :: UVector Double -> Int -> IO Double #-}
-  getNth = UV.unsafeRead
-  {-# SPECIALIZE INLINE setNth :: UVector Double -> Int -> Double -> IO () #-}
-  setNth = UV.unsafeWrite
-  {-# SPECIALIZE INLINE modifyNth :: UVector Double -> (Double -> Double) -> Int -> IO () #-}
-  modifyNth = UV.unsafeModify
-  {-# SPECIALIZE INLINE swapBetween:: UVector Double -> Int -> Int -> IO () #-}
-  swapBetween = UV.unsafeSwap
-  {-# SPECIALIZE INLINE newVec :: Int -> Double -> IO (UVector Double) #-}
-  newVec n x = do v <- UV.new n
-                  UV.set v x
-                  return v
-  {-# SPECIALIZE INLINE setAll :: UVector Double -> Double -> IO () #-}
-  setAll = UV.set
-  {-# SPECIALIZE INLINE growBy :: UVector Double -> Int -> IO (UVector Double) #-}
-  growBy = UV.unsafeGrow
-  asList v = mapM (UV.unsafeRead v) [0 .. UV.length v - 1]
-
-instance VecFamily (Vec Double) Double where
-  {-# SPECIALIZE INLINE getNth :: Vec Double -> Int -> IO Double #-}
-  getNth (Vec v) = UV.unsafeRead v
-  {-# SPECIALIZE INLINE setNth :: Vec Double -> Int -> Double -> IO () #-}
-  setNth (Vec v) = UV.unsafeWrite v
-  {-# SPECIALIZE INLINE modifyNth :: Vec Double -> (Double -> Double) -> Int -> IO () #-}
-  modifyNth (Vec v) = UV.unsafeModify v
-  {-# SPECIALIZE INLINE swapBetween :: Vec Double -> Int -> Int -> IO () #-}
-  swapBetween (Vec v) = UV.unsafeSwap v
-  {-# SPECIALIZE INLINE newVec :: Int -> Double -> IO (Vec Double) #-}
-  newVec n x = Vec <$> newVec (n + 1) x
-  {-# SPECIALIZE INLINE setAll :: Vec Double -> Double -> IO () #-}
-  setAll (Vec v) = UV.set v
-  {-# SPECIALIZE INLINE growBy :: Vec Double -> Int -> IO (Vec Double) #-}
-  growBy (Vec v) n = Vec <$> UV.unsafeGrow v n
--}
-
 -------------------------------------------------------------------------------- ByteArray
 
 data instance Vec Int = ByteArrayInt (BA.MutableByteArray RealWorld)
@@ -183,6 +120,7 @@ instance VecFamily ByteArrayInt Int where
                                         BA.writeByteArray v j (x :: Int)
   {-# SPECIALIZE INLINE reset :: ByteArrayInt -> IO () #-}
   reset (ByteArrayInt v) = BA.writeByteArray v 0 (0 :: Int)
+  {-# SPECIALIZE INLINE newVec :: Int -> Int -> IO ByteArrayInt #-}
   newVec n k = do v <- BA.newByteArray (8 * (n + 1))
                   BA.writeByteArray v 0 (0 :: Int)
                   BA.setByteArray v 1 n k
@@ -206,6 +144,7 @@ instance VecFamily ByteArrayDouble Double where
                                            BA.writeByteArray v j (x :: Int)
   {-# SPECIALIZE INLINE reset :: ByteArrayDouble -> IO () #-}
   reset (ByteArrayDouble v) = BA.writeByteArray v 0 (0 :: Double)
+  {-# SPECIALIZE INLINE newVec :: Int -> Double -> IO ByteArrayDouble #-}
   newVec n k = do v <- BA.newByteArray (8 * (n + 1))
                   BA.writeByteArray v 0 (0 :: Double)
                   BA.setByteArray v 1 n k


### PR DESCRIPTION
- sort clauses with the '_keyVector' field in ClauseExtManager
#### Related branches

- #85 
  - .0 2nd EMA, ACIDS
  - .1 sort doubled keyVector
  - .2 sort with both vectors (cherry-picking #84)
- #84 (sort with both vectors without ACIDS)
- #81 (simplified w/o EA, w/o 2nd EMA)
- #79 ACIDS

